### PR TITLE
Fix layout width for HOI4 page

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,12 @@
         display: block;
       }
 
+      /* A HOI4 sorsoló szekciónál ne legyen szélességkorlát, hogy a négy doboz egymás mellett
+         maradjon */
+      #sorsolas {
+        max-width: none;
+      }
+
       footer {
         padding: 1rem;
         font-size: 0.875rem;


### PR DESCRIPTION
## Summary
- keep HOI4 drawing section full width so the four boxes can stay side-by-side

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eeb7f18708327ab0aead8ea2058fd