### PR TITLE
Fix footer color and width

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
         min-height: 100vh;
         display: flex;
         flex-direction: column;
+        align-items: stretch;
         text-align: center;
         padding: 0; /* Remove outer spacing so header and footer reach page edges */
       }
@@ -104,11 +105,12 @@
         max-width: none;
       }
 
-      footer {
-        padding: 1rem;
-        font-size: 0.875rem;
-        background: #202225;
-      }
+        footer {
+          width: 100%;
+          padding: 1rem;
+          font-size: 0.875rem;
+          background: rgb(47, 49, 54);
+        }
     </style>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- stretch layout items so footer spans the page width
- color footer background in rgb(47,49,54)

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684eedc0b58c8327bae5dbe5e0fa1841