### PR TITLE
Limit poll loading to polls section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1257,6 +1257,10 @@
           loadVideos();
         }
 
+        if (target === "szavazas") {
+          refreshPollsIfVisible();
+        }
+
         if (shouldPushState) {
           history.pushState(null, "", `#${target}`);
         }
@@ -1303,6 +1307,7 @@
     const optionsContainer = document.getElementById("optionsContainer");
     const addOptionBtn = document.getElementById("addOptionBtn");
     const pollListContainer = document.getElementById("pollList");
+    const pollSection = document.getElementById("szavazas");
 
     const SESSION_KEYS = {
       token: "token",
@@ -1310,6 +1315,25 @@
       isAdmin: ADMIN_SESSION_KEY,
     };
     const POLL_MIN_OPTIONS = 2;
+    let pollsShouldRefresh = true;
+
+    function isPollSectionActive() {
+      return pollSection?.classList.contains("active");
+    }
+
+    function refreshPollsIfVisible() {
+      if (!isPollSectionActive() || !pollsShouldRefresh) {
+        return;
+      }
+
+      pollsShouldRefresh = false;
+      loadPolls();
+    }
+
+    function markPollsForRefresh() {
+      pollsShouldRefresh = true;
+      refreshPollsIfVisible();
+    }
 
     function storeSessionData({ token, username, isAdmin }) {
       if (typeof token === "string" && token.trim()) {
@@ -1594,6 +1618,8 @@
         return;
       }
 
+      pollsShouldRefresh = false;
+
       pollListContainer.innerHTML = "";
       const loadingElement = document.createElement("div");
       loadingElement.className = "poll-empty";
@@ -1820,7 +1846,7 @@
 
     ensureMinimumOptionRows();
     updatePollCreatorState();
-    loadPolls();
+    markPollsForRefresh();
 
     function updateAdminNavVisibility() {
       const isAdmin = isAdminUser();
@@ -1864,7 +1890,7 @@
 
       updateAdminNavVisibility();
       updatePollCreatorState(true);
-      loadPolls();
+      markPollsForRefresh();
     }
 
     function updateUIForLoggedOut() {
@@ -1879,7 +1905,7 @@
       }
       updateAdminNavVisibility();
       updatePollCreatorState(false);
-      loadPolls();
+      markPollsForRefresh();
     }
 
     if (loginBtn) {


### PR DESCRIPTION
### **User description**
## Summary
- fetch poll data only when the polls section is active
- track when poll data needs to refresh so navigation or auth changes reload as needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6908aaca44988327bb5af417e6afb160


___

### **PR Type**
Enhancement


___

### **Description**
- Defer poll loading until polls section becomes active

- Track poll refresh state to reload on navigation/auth changes

- Replace immediate `loadPolls()` calls with `markPollsForRefresh()`

- Implement lazy loading pattern for polls data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Navigation to polls section"] --> B["refreshPollsIfVisible()"]
  C["Auth state change"] --> D["markPollsForRefresh()"]
  B --> E["Load polls if needed"]
  D --> E
  F["Other sections active"] --> G["Skip poll loading"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Implement lazy loading for polls section</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

index.html

<ul><li>Added <code>pollSection</code> reference and <code>pollsShouldRefresh</code> state flag<br> <li> Implemented <code>isPollSectionActive()</code>, <code>refreshPollsIfVisible()</code>, and <br><code>markPollsForRefresh()</code> helper functions<br> <li> Added conditional poll refresh trigger in section navigation handler<br> <li> Replaced direct <code>loadPolls()</code> calls with <code>markPollsForRefresh()</code> in <br>initialization and auth handlers<br> <li> Set <code>pollsShouldRefresh = false</code> at start of <code>loadPolls()</code> to prevent <br>duplicate loads</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/32/files#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051">+29/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

