### PR TITLE
Ensure upload directories exist before video and avatar uploads

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -23,9 +23,22 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 // Fájlfeltöltés beállítása a videókhoz
+const uploadsDirectory = path.join(__dirname, '..', 'public', 'uploads');
+const ensureDirectoryExists = (dirPath) => {
+    try {
+        fs.mkdirSync(dirPath, { recursive: true });
+    } catch (err) {
+        if (err.code !== 'EEXIST') {
+            throw err;
+        }
+    }
+};
+
+ensureDirectoryExists(uploadsDirectory);
+
 const storage = multer.diskStorage({
     destination: (req, file, cb) => {
-        cb(null, path.join(__dirname, '..', 'public', 'uploads'));
+        cb(null, uploadsDirectory);
     },
     filename: (req, file, cb) => {
         const uniqueName = `${Date.now()}-${Math.round(Math.random() * 1e9)}${path.extname(file.originalname)}`;
@@ -536,9 +549,12 @@ app.post('/upload', authenticateToken, loadUserUploadSettings, (req, res, next) 
 });
 
 // Avatar feltöltés beállítása
+const avatarDirectory = path.join(uploadsDirectory, 'avatars');
+ensureDirectoryExists(avatarDirectory);
+
 const avatarStorage = multer.diskStorage({
     destination: (req, file, cb) => {
-        cb(null, path.join(__dirname, '..', 'public', 'uploads', 'avatars'));
+        cb(null, avatarDirectory);
     },
     filename: (req, file, cb) => {
         const uniqueName = `${Date.now()}-${Math.round(Math.random() * 1e9)}${path.extname(file.originalname)}`;


### PR DESCRIPTION
### **User description**
## Summary
- create a helper to make sure the public upload directories exist before handling uploads
- reuse the helper for both video and avatar storage configurations to prevent ENOENT errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690a10455f708327900069029d786161


___

### **PR Type**
Bug fix


___

### **Description**
- Create helper function to ensure upload directories exist before file operations

- Apply directory creation to both video and avatar upload paths

- Prevent ENOENT errors by recursively creating directories with proper error handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ensureDirectoryExists helper"] -- "creates recursively" --> B["uploadsDirectory"]
  A -- "creates recursively" --> C["avatarDirectory"]
  B -- "used by" --> D["video storage config"]
  C -- "used by" --> E["avatar storage config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Add directory creation helper for upload paths</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.js

<ul><li>Added <code>ensureDirectoryExists()</code> helper function that recursively creates <br>directories and handles EEXIST errors<br> <li> Defined <code>uploadsDirectory</code> constant and called helper to ensure it <br>exists before video storage initialization<br> <li> Defined <code>avatarDirectory</code> constant and called helper to ensure it exists <br>before avatar storage initialization<br> <li> Refactored multer storage configurations to use directory constants <br>instead of inline path joins</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/52/files#diff-79f4c7cdc0b026f6e556196f5911a449157807cffdb3f9d33f0b5404b4ffc2f3">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

