### PR TITLE
Enhance P2P connection setup and placeholder asset handling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1795,19 +1795,19 @@
             <button class="download-btn" disabled>Letöltés</button>
           </div>
           <div class="box">
-            <img src="program_icons/placeholder.png" alt="Program ikon" class="program-icon" />
+            <img src="program_icons/default-avatar.png" alt="Program ikon" class="program-icon" />
             <h3>Program 2</h3>
             <p>Hamarosan...</p>
             <button class="download-btn" disabled>Letöltés</button>
           </div>
           <div class="box">
-            <img src="program_icons/placeholder.png" alt="Program ikon" class="program-icon" />
+            <img src="program_icons/default-avatar.png" alt="Program ikon" class="program-icon" />
             <h3>Program 3</h3>
             <p>Hamarosan...</p>
             <button class="download-btn" disabled>Letöltés</button>
           </div>
           <div class="box">
-            <img src="program_icons/placeholder.png" alt="Program ikon" class="program-icon" />
+            <img src="program_icons/default-avatar.png" alt="Program ikon" class="program-icon" />
             <h3>Program 4</h3>
             <p>Hamarosan...</p>
             <button class="download-btn" disabled>Letöltés</button>
@@ -2698,7 +2698,21 @@
       }
 
       peer = new Peer({
-        config: { iceServers: [{ urls: "stun:stun.l.google.com:19302" }] },
+        config: {
+          iceServers: [
+            { urls: "stun:stun.l.google.com:19302" },
+            { urls: "stun:stun1.l.google.com:19302" },
+            { urls: "stun:stun2.l.google.com:19302" },
+            { urls: "stun:stun3.l.google.com:19302" },
+            { urls: "stun:stun4.l.google.com:19302" },
+            { urls: "stun:stun.framasoft.org" },
+            { urls: "stun:stun.voip.blackberry.com:3478" },
+            { urls: "stun:stun.antisip.com" },
+            { urls: "stun:stun.sipgate.net" },
+            { urls: "stun:openrelay.metered.ca:80" },
+          ],
+          iceCandidatePoolSize: 10,
+        },
       });
       peer.on("open", (id) => {
         peerId = id;
@@ -2991,12 +3005,17 @@
       const conn = peer.connect(receiver.peerId);
       const transferId = `outgoing-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
+      const safeName = file?.name || "ismeretlen_fajl";
+      const safeSize = typeof file?.size === "number" ? file.size : 0;
+      const safeType =
+        file?.type && file.type.trim() !== "" ? file.type : "application/octet-stream";
+
       const transfer = createTransferCard({
         id: transferId,
         direction: "outgoing",
-        name: file.name,
-        size: file.size,
-        mimeType: file.type,
+        name: safeName,
+        size: safeSize,
+        mimeType: safeType,
         status: `Kapcsolódás ${receiver.username} felé...`,
       });
 
@@ -3025,7 +3044,7 @@
       conn.on("open", () => {
         clearTimeout(connectionTimeout);
         updateTransferStatus(transfer, "Kapcsolat létrejött, metaadat küldése...");
-        conn.send({ type: "meta", name: file.name, size: file.size, mimeType: file.type });
+        conn.send({ type: "meta", name: safeName, size: safeSize, mimeType: safeType });
       });
 
       conn.on("data", async (data) => {


### PR DESCRIPTION
### **User description**
## Summary
- expand PeerJS ICE configuration with multiple public STUN servers and larger candidate pool
- replace missing placeholder image references with the existing default avatar asset
- harden outgoing file metadata to default missing mime types for Safari compatibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939e87213488327bf31cd4e13768655)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace missing placeholder image references with default avatar asset

- Expand PeerJS ICE configuration with multiple STUN servers

- Add larger ICE candidate pool size for improved connectivity

- Harden outgoing file metadata with safe defaults for Safari compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["File Transfer Setup"] --> B["Safe File Metadata"]
  A --> C["PeerJS Configuration"]
  B --> D["Default MIME Type Fallback"]
  C --> E["Multiple STUN Servers"]
  C --> F["Larger Candidate Pool"]
  G["HTML Assets"] --> H["Replace Placeholder Images"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement, bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>P2P connection robustness and file metadata safety improvements</code></dd></summary>
<hr>

public/index.html

<ul><li>Replace 3 instances of <code>program_icons/placeholder.png</code> with <br><code>program_icons/default-avatar.png</code><br> <li> Expand PeerJS ICE configuration from single Google STUN server to 10 <br>diverse STUN servers<br> <li> Add <code>iceCandidatePoolSize: 10</code> configuration parameter<br> <li> Implement safe file metadata handling with fallback defaults for name, <br>size, and MIME type<br> <li> Use <code>application/octet-stream</code> as default MIME type when file type is <br>missing or empty</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/67/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd">+27/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

