### PR TITLE
Hide file transfer menu without permissions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1454,7 +1454,14 @@
       <h1>UMGKL HUB</h1>
       <nav>
         <a href="#home" data-section="home" class="active">Főoldal</a>
-        <a href="#fajlkuldes" data-section="fajlkuldes">Fájlküldés</a>
+        <a
+          href="#fajlkuldes"
+          data-section="fajlkuldes"
+          id="fileTransferNavBtn"
+          data-requires-transfer="true"
+          style="display: none;"
+          >Fájlküldés</a
+        >
         <a href="#klipek" data-section="klipek">Klippek</a>
         <a href="#sorsolas" data-section="sorsolas">Hoi4 Sorsolás</a>
         <a href="#szavazas" data-section="szavazas">Szavazás</a>
@@ -1912,9 +1919,24 @@
         return localStorage.getItem(ADMIN_SESSION_KEY) === "true";
       }
 
+      function hasFileTransferPermission() {
+        return isUserLoggedIn() && localStorage.getItem(SESSION_KEYS.canTransfer) === "true";
+      }
+
       function getAccessibleNavLinks() {
         return Array.from(document.querySelectorAll("nav a")).filter((link) => {
-          return !(link.dataset.requiresAdmin === "true" && !isAdminUser());
+          const requiresAdmin = link.dataset.requiresAdmin === "true";
+          const requiresTransfer = link.dataset.requiresTransfer === "true";
+
+          if (requiresAdmin && !isAdminUser()) {
+            return false;
+          }
+
+          if (requiresTransfer && !hasFileTransferPermission()) {
+            return false;
+          }
+
+          return true;
         });
       }
 
@@ -2175,9 +2197,13 @@
 
         document.querySelectorAll("nav a").forEach((link) => {
           const requiresAdmin = link.dataset.requiresAdmin === "true";
+          const requiresTransfer = link.dataset.requiresTransfer === "true";
           const isActive = link.dataset.section === target;
 
-          if (requiresAdmin && !isAdminUser()) {
+          if (
+            (requiresAdmin && !isAdminUser()) ||
+            (requiresTransfer && !hasFileTransferPermission())
+          ) {
             link.classList.remove("active");
             return;
           }
@@ -2211,8 +2237,14 @@
       document.querySelectorAll("nav a").forEach((link) => {
         link.addEventListener("click", (e) => {
           const requiresAdmin = link.dataset.requiresAdmin === "true";
+          const requiresTransfer = link.dataset.requiresTransfer === "true";
 
           if (requiresAdmin && !isAdminUser()) {
+            e.preventDefault();
+            return;
+          }
+
+          if (requiresTransfer && !hasFileTransferPermission()) {
             e.preventDefault();
             return;
           }
@@ -2241,6 +2273,7 @@
     const userGreeting = document.getElementById("userGreeting");
     const adminNavBtn = document.getElementById("adminNavBtn");
     const programNavBtn = document.getElementById("programNavBtn");
+    const fileTransferNavBtn = document.getElementById("fileTransferNavBtn");
     const userListContainer = document.getElementById("userListContainer");
     const savePermissionsBtn = document.getElementById("savePermissionsBtn");
     const pollCreator = document.getElementById("pollCreator");
@@ -2265,6 +2298,7 @@
       token: "token",
       username: "username",
       isAdmin: ADMIN_SESSION_KEY,
+      canTransfer: "canTransfer",
       profilePictureFilename: "profilePictureFilename",
     };
     const POLL_MIN_OPTIONS = 2;
@@ -3719,6 +3753,21 @@
       }
     }
 
+    function updateFileTransferNavVisibility() {
+      const hasAccess = hasFileTransferPermission();
+
+      if (fileTransferNavBtn) {
+        fileTransferNavBtn.style.display = hasAccess ? "inline-block" : "none";
+      }
+
+      if (!hasAccess) {
+        const activeSection = document.querySelector("main section.active");
+        if (activeSection && activeSection.id === "fajlkuldes") {
+          showSection("home");
+        }
+      }
+    }
+
     function updateUIForLoggedIn(username, profilePictureFilename) {
       if (userGreeting) {
         userGreeting.textContent = username;
@@ -3752,10 +3801,17 @@
       }
 
       updateAdminNavVisibility();
+      updateFileTransferNavVisibility();
       updatePollCreatorState(true);
       markPollsForRefresh();
-      initializeRealtimeFeatures();
-      updateReceiverStatus("Kapcsolódj a fogadó módhoz a kapcsolóval.");
+
+      if (hasFileTransferPermission()) {
+        initializeRealtimeFeatures();
+        updateReceiverStatus("Kapcsolódj a fogadó módhoz a kapcsolóval.");
+      } else {
+        teardownRealtimeFeatures();
+        updateReceiverStatus("Nincs jogosultságod a fájlküldéshez.");
+      }
     }
 
     function updateUIForLoggedOut() {
@@ -3763,6 +3819,7 @@
       localStorage.removeItem(SESSION_KEYS.token);
       localStorage.removeItem(SESSION_KEYS.username);
       localStorage.removeItem(SESSION_KEYS.isAdmin);
+      localStorage.removeItem(SESSION_KEYS.canTransfer);
       localStorage.removeItem(SESSION_KEYS.profilePictureFilename);
 
       if (authLoggedOut) {
@@ -3792,6 +3849,7 @@
         newUsernameInput.value = '';
       }
       updateAdminNavVisibility();
+      updateFileTransferNavVisibility();
       updatePollCreatorState(false);
       markPollsForRefresh();
       teardownRealtimeFeatures();
@@ -4105,9 +4163,11 @@
         const data = await res.json();
 
         if (res.ok) {
+          const canTransfer = data.canTransfer === true || data.canTransfer === 1;
           localStorage.setItem(SESSION_KEYS.token, data.token);
           localStorage.setItem(SESSION_KEYS.username, data.username);
           localStorage.setItem(SESSION_KEYS.isAdmin, data.isAdmin);
+          localStorage.setItem(SESSION_KEYS.canTransfer, canTransfer ? "true" : "false");
           if (data.profile_picture_filename) {
             localStorage.setItem(SESSION_KEYS.profilePictureFilename, data.profile_picture_filename);
           } else {
@@ -4173,6 +4233,8 @@
             localStorage.setItem(SESSION_KEYS.token, token); // The token is still valid
             localStorage.setItem(SESSION_KEYS.username, data.username);
             localStorage.setItem(SESSION_KEYS.isAdmin, data.isAdmin);
+            const canTransfer = data.canTransfer === true || data.canTransfer === 1;
+            localStorage.setItem(SESSION_KEYS.canTransfer, canTransfer ? "true" : "false");
             if (data.profile_picture_filename) {
                 localStorage.setItem(SESSION_KEYS.profilePictureFilename, data.profile_picture_filename);
             } else {

--- a/src/server.js
+++ b/src/server.js
@@ -304,7 +304,7 @@ app.post('/login', async (req, res) => {
     }
 
     try {
-        const { rows } = await db.query('SELECT id, username, password, is_admin, profile_picture_filename FROM users WHERE username = $1', [username]);
+        const { rows } = await db.query('SELECT id, username, password, is_admin, can_transfer, profile_picture_filename FROM users WHERE username = $1', [username]);
         const user = rows[0];
 
         if (!user) {
@@ -325,6 +325,7 @@ app.post('/login', async (req, res) => {
             token,
             username: user.username,
             isAdmin,
+            canTransfer: Number(user.can_transfer) === 1,
             profile_picture_filename: user.profile_picture_filename
         });
     } catch (err) {
@@ -339,7 +340,7 @@ app.post('/logout', (req, res) => {
 
 app.get('/api/profile', authenticateToken, async (req, res) => {
     try {
-        const { rows } = await db.query('SELECT id, username, is_admin, profile_picture_filename FROM users WHERE id = $1', [req.user.id]);
+        const { rows } = await db.query('SELECT id, username, is_admin, can_transfer, profile_picture_filename FROM users WHERE id = $1', [req.user.id]);
         const user = rows[0];
 
         if (!user) {
@@ -350,6 +351,7 @@ app.get('/api/profile', authenticateToken, async (req, res) => {
             id: user.id,
             username: user.username,
             isAdmin: user.is_admin === 1,
+            canTransfer: Number(user.can_transfer) === 1,
             profile_picture_filename: user.profile_picture_filename
         });
     } catch (err) {


### PR DESCRIPTION
### **User description**
## Summary
- return file transfer permission with login and profile responses
- store the permission on the client and hide the Fájlküldés navigation item when access is missing
- avoid initializing realtime transfer features for users without the required rights

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939ec6b809c8327a48075239a87c80d)


___

### **PR Type**
Enhancement


___

### **Description**
- Add file transfer permission system with database integration

- Hide file transfer navigation menu for unauthorized users

- Conditionally initialize realtime features based on permissions

- Store and validate transfer permissions in login and profile responses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Login"] -->|"Fetch canTransfer"| B["Server Response"]
  B -->|"Store in localStorage"| C["hasFileTransferPermission()"]
  C -->|"Check Permission"| D["Update UI Visibility"]
  D -->|"Show/Hide Menu"| E["File Transfer Nav"]
  D -->|"Initialize/Teardown"| F["Realtime Features"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add file transfer permission UI controls and validation</code>&nbsp; &nbsp; </dd></summary>
<hr>

public/index.html

<ul><li>Added <code>id="fileTransferNavBtn"</code> and <code>data-requires-transfer="true"</code> <br>attributes to file transfer navigation link with initial <code>display: none</code> <br>style<br> <li> Implemented <code>hasFileTransferPermission()</code> function to check login status <br>and <code>canTransfer</code> localStorage flag<br> <li> Enhanced <code>getAccessibleNavLinks()</code> to filter navigation links based on <br>transfer permissions alongside admin requirements<br> <li> Added <code>updateFileTransferNavVisibility()</code> function to show/hide file <br>transfer menu and redirect from file transfer section if access denied<br> <li> Updated login and profile response handlers to extract and store <br><code>canTransfer</code> permission from server responses<br> <li> Modified <code>updateUIForLoggedIn()</code> to conditionally initialize realtime <br>features only for users with transfer permissions<br> <li> Updated logout handler to clear <code>canTransfer</code> from localStorage<br> <li> Added transfer permission checks in navigation click handlers to <br>prevent unauthorized access</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/70/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd">+67/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Include file transfer permission in auth responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.js

<ul><li>Modified <code>/login</code> endpoint to query <code>can_transfer</code> column from users table <br>and include it in response<br> <li> Modified <code>/api/profile</code> endpoint to query and return <code>can_transfer</code> <br>permission status<br> <li> Convert <code>can_transfer</code> database values to boolean in both endpoints for <br>consistent client-side handling</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/70/files#diff-79f4c7cdc0b026f6e556196f5911a449157807cffdb3f9d33f0b5404b4ffc2f3">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

