### PR TITLE
Add Discord-style avatar cropper modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,144 @@
       referrerpolicy="no-referrer"
     ></script>
     <style>
+      .avatar-cropper-modal {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(0, 0, 0, 0.65);
+        z-index: 1200;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.25s ease;
+      }
+
+      .avatar-cropper-modal.open {
+        opacity: 1;
+        pointer-events: auto;
+      }
+
+      .avatar-cropper-dialog {
+        background: #2b2d31;
+        border-radius: 16px;
+        width: min(780px, 94vw);
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        overflow: hidden;
+        color: #e4e6eb;
+      }
+
+      .avatar-cropper-header {
+        padding: 1.1rem 1.4rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+        background: #36393f;
+      }
+
+      .avatar-cropper-header h3 {
+        margin: 0;
+        font-size: 1.15rem;
+        letter-spacing: 0.01em;
+      }
+
+      .avatar-cropper-body {
+        padding: 1.4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        background: #2f3136;
+      }
+
+      .avatar-cropper-canvas {
+        background: #1f2125;
+        border-radius: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.04);
+        padding: 0.75rem;
+        display: grid;
+        place-items: center;
+        min-height: 360px;
+      }
+
+      .avatar-cropper-canvas img {
+        max-width: 100%;
+        display: block;
+      }
+
+      .avatar-zoom-control {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: #25272b;
+        padding: 0.75rem 1rem;
+        border-radius: 12px;
+        border: 1px solid rgba(255, 255, 255, 0.04);
+      }
+
+      .avatar-zoom-control .zoom-icon {
+        opacity: 0.8;
+        font-size: 0.95rem;
+      }
+
+      .avatar-zoom-range {
+        flex: 1;
+        accent-color: #5865f2;
+        height: 6px;
+      }
+
+      .avatar-zoom-range::-webkit-slider-runnable-track {
+        background: linear-gradient(90deg, #4e5bd5, #5865f2);
+        height: 6px;
+        border-radius: 999px;
+      }
+
+      .avatar-zoom-range::-moz-range-track {
+        background: linear-gradient(90deg, #4e5bd5, #5865f2);
+        height: 6px;
+        border-radius: 999px;
+      }
+
+      .avatar-zoom-range::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #fff;
+        border: 2px solid #5865f2;
+        margin-top: -6px;
+        box-shadow: 0 6px 18px rgba(88, 101, 242, 0.4);
+      }
+
+      .avatar-zoom-range::-moz-range-thumb {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        background: #fff;
+        border: 2px solid #5865f2;
+        box-shadow: 0 6px 18px rgba(88, 101, 242, 0.4);
+      }
+
+      .avatar-cropper-footer {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+        padding: 1rem 1.4rem 1.3rem;
+        background: #2b2d31;
+        border-top: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .cropper-view-box,
+      .cropper-face {
+        border-radius: 50% !important;
+      }
+
+      .cropper-view-box {
+        box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.85);
+      }
+
+      .cropper-modal {
+        background-color: rgba(0, 0, 0, 0.35);
+      }
+
       #fajlkuldes {
         background: rgba(24, 25, 28, 0.95);
         border-radius: 16px;
@@ -2547,6 +2685,37 @@
       </section>
     </main>
 
+    <div id="avatarCropperModal" class="avatar-cropper-modal" aria-hidden="true">
+      <div class="avatar-cropper-dialog" role="dialog" aria-modal="true" aria-labelledby="avatarCropperTitle">
+        <div class="avatar-cropper-header">
+          <h3 id="avatarCropperTitle">Kép szerkesztése</h3>
+        </div>
+        <div class="avatar-cropper-body">
+          <div class="avatar-cropper-canvas">
+            <img id="avatarCropperImage" src="" alt="Avatar kivágás" />
+          </div>
+          <div class="avatar-zoom-control">
+            <span class="zoom-icon" aria-hidden="true">🖼️</span>
+            <input
+              type="range"
+              id="avatarZoomRange"
+              class="avatar-zoom-range"
+              min="0.5"
+              max="3"
+              step="0.01"
+              value="1"
+              aria-label="Nagyítás"
+            />
+            <span class="zoom-icon" aria-hidden="true" style="font-size: 1.1rem;">🖼️</span>
+          </div>
+        </div>
+        <div class="avatar-cropper-footer">
+          <button type="button" id="avatarCropperCancel" class="ghost-button">Mégse</button>
+          <button type="button" id="avatarCropperSave" class="primary-button">Mentés</button>
+        </div>
+      </div>
+    </div>
+
     <footer>
       <p>© 2025 UMGKL HUB Minden jog fenntartva</p>
     </footer>
@@ -4752,30 +4921,126 @@
     const avatarInput = document.getElementById('avatarInput');
     const avatarUploadStatus = document.getElementById('avatarUploadStatus');
     const profileAvatarPreview = document.getElementById('profileAvatarPreview');
+    const avatarCropperModal = document.getElementById('avatarCropperModal');
+    const avatarCropperImage = document.getElementById('avatarCropperImage');
+    const avatarCropperCancel = document.getElementById('avatarCropperCancel');
+    const avatarCropperSave = document.getElementById('avatarCropperSave');
+    const avatarZoomRange = document.getElementById('avatarZoomRange');
     let avatarPreviewObjectUrl = null;
+    let avatarCropperInstance = null;
+    let croppedAvatarBlob = null;
+    let avatarOriginalFileName = '';
 
-    if (avatarInput && profileAvatarPreview) {
+    const closeAvatarCropper = (resetSelection = false) => {
+        if (avatarCropperModal) {
+            avatarCropperModal.classList.remove('open');
+            avatarCropperModal.setAttribute('aria-hidden', 'true');
+        }
+
+        if (avatarCropperInstance) {
+            avatarCropperInstance.destroy();
+            avatarCropperInstance = null;
+        }
+
+        if (resetSelection && avatarInput) {
+            avatarInput.value = '';
+        }
+
+        if (avatarZoomRange) {
+            avatarZoomRange.value = '1';
+        }
+
+        if (avatarCropperImage) {
+            avatarCropperImage.src = '';
+        }
+    };
+
+    if (avatarInput && profileAvatarPreview && avatarCropperImage && avatarCropperModal) {
         avatarInput.addEventListener('change', () => {
             const file = avatarInput.files[0];
 
-            if (avatarPreviewObjectUrl) {
-                URL.revokeObjectURL(avatarPreviewObjectUrl);
-                avatarPreviewObjectUrl = null;
-            }
-
             if (!file) {
-                delete profileAvatarPreview.dataset.override;
-                const storedAvatar = localStorage.getItem(SESSION_KEYS.profilePictureFilename);
-                profileAvatarPreview.src = storedAvatar ? `/uploads/avatars/${storedAvatar}` : 'program_icons/default-avatar.png';
                 return;
             }
 
-            avatarPreviewObjectUrl = URL.createObjectURL(file);
-            profileAvatarPreview.src = avatarPreviewObjectUrl;
-            profileAvatarPreview.dataset.override = 'true';
+            avatarOriginalFileName = file.name;
+            croppedAvatarBlob = null;
+
             if (avatarUploadStatus) {
-              avatarUploadStatus.textContent = '';
+                avatarUploadStatus.textContent = '';
             }
+
+            const reader = new FileReader();
+            reader.onload = () => {
+                avatarCropperImage.src = reader.result;
+
+                if (avatarCropperInstance) {
+                    avatarCropperInstance.destroy();
+                }
+
+                avatarCropperInstance = new Cropper(avatarCropperImage, {
+                    aspectRatio: 1,
+                    viewMode: 1,
+                    dragMode: 'move',
+                    autoCropArea: 1,
+                    ready() {
+                        if (avatarZoomRange) {
+                            avatarZoomRange.value = '1';
+                        }
+                        avatarCropperInstance.zoomTo(1);
+                    },
+                });
+
+                avatarCropperModal.classList.add('open');
+                avatarCropperModal.setAttribute('aria-hidden', 'false');
+            };
+
+            reader.readAsDataURL(file);
+        });
+    }
+
+    if (avatarZoomRange) {
+        avatarZoomRange.addEventListener('input', (event) => {
+            if (avatarCropperInstance) {
+                const zoomValue = parseFloat(event.target.value);
+                avatarCropperInstance.zoomTo(zoomValue);
+            }
+        });
+    }
+
+    if (avatarCropperCancel) {
+        avatarCropperCancel.addEventListener('click', () => {
+            croppedAvatarBlob = null;
+            closeAvatarCropper(true);
+        });
+    }
+
+    if (avatarCropperSave) {
+        avatarCropperSave.addEventListener('click', () => {
+            if (!avatarCropperInstance) return;
+
+            const canvas = avatarCropperInstance.getCroppedCanvas({ width: 512, height: 512, imageSmoothingQuality: 'high' });
+            canvas.toBlob((blob) => {
+                if (!blob) return;
+
+                croppedAvatarBlob = blob;
+
+                if (avatarPreviewObjectUrl) {
+                    URL.revokeObjectURL(avatarPreviewObjectUrl);
+                }
+
+                avatarPreviewObjectUrl = URL.createObjectURL(blob);
+                profileAvatarPreview.src = avatarPreviewObjectUrl;
+                profileAvatarPreview.dataset.override = 'true';
+                if (avatarUploadStatus) {
+                    avatarUploadStatus.textContent = '';
+                }
+
+                closeAvatarCropper();
+                if (avatarInput) {
+                    avatarInput.value = '';
+                }
+            }, 'image/png');
         });
     }
 
@@ -4787,13 +5052,17 @@
             }
 
             const file = avatarInput.files[0];
-            if (!file) {
+            if (!file && !croppedAvatarBlob) {
                 alert("Válassz ki egy képfájlt a feltöltéshez.");
                 return;
             }
 
             const formData = new FormData();
-            formData.append('avatar', file);
+            if (croppedAvatarBlob) {
+                formData.append('avatar', croppedAvatarBlob, avatarOriginalFileName || 'avatar.png');
+            } else if (file) {
+                formData.append('avatar', file);
+            }
 
             uploadAvatarBtn.disabled = true;
             avatarUploadStatus.textContent = "Feltöltés folyamatban...";
@@ -4818,6 +5087,8 @@
                     avatarPreviewObjectUrl = null;
                 }
                 delete profileAvatarPreview.dataset.override;
+                croppedAvatarBlob = null;
+                avatarOriginalFileName = '';
                 await ensureSessionOnLoad(); // Refresh session data to get new avatar filename
             } catch (error) {
                 console.error('Profilkép feltöltési hiba:', error);


### PR DESCRIPTION
### **User description**
## Summary
- add a Discord-like avatar cropper modal with circular mask and zoom control
- load selected avatar images into the modal for editing before previewing or uploading
- send the cropped image blob on upload and refresh preview/status handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f540646488327a128eada45648ccb)


___

### **PR Type**
Enhancement


___

### **Description**
- Add Discord-style avatar cropper modal with circular mask

- Implement zoom control slider for image adjustment

- Load selected images into modal before upload

- Send cropped image blob on upload with proper cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User selects image"] -->|FileReader| B["Load into cropper modal"]
  B -->|Zoom slider| C["Adjust image zoom"]
  C -->|Save button| D["Generate 512x512 blob"]
  D -->|Upload button| E["Send blob to server"]
  E -->|Success| F["Refresh avatar preview"]
  B -->|Cancel button| G["Close modal & reset"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add avatar cropper modal with zoom and upload</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/index.html

<ul><li>Added comprehensive Discord-themed CSS styles for avatar cropper <br>modal, dialog, header, body, canvas, zoom control, and footer<br> <li> Integrated cropper.js library via CDN with integrity and crossorigin <br>attributes<br> <li> Added HTML modal structure with image element, zoom range slider, and <br>action buttons<br> <li> Implemented JavaScript event listeners for file selection, zoom <br>control, cancel, and save operations<br> <li> Modified upload logic to handle cropped image blob instead of raw file<br> <li> Added cleanup and state management for cropper instance and preview <br>URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/79/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd">+286/-15</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

