### PR TITLE
Fix program storage initialization order

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -56,8 +56,6 @@ const storage = multer.diskStorage({
     }
 });
 
-const uploadProgramFiles = multer({ storage: programStorage });
-
 async function safeUnlink(filePath) {
     try {
         await fs.promises.unlink(filePath);
@@ -83,6 +81,8 @@ const programStorage = multer.diskStorage({
         cb(null, uniqueName);
     }
 });
+
+const uploadProgramFiles = multer({ storage: programStorage });
 
 function getNumberSetting(value, defaultValue) {
     const parsed = Number(value);


### PR DESCRIPTION
### **User description**
## Summary
- move programStorage definition above uploadProgramFiles to prevent initialization errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f54a52cf08327b0fd08b794b92292)


___

### **PR Type**
Bug fix


___

### **Description**
- Move `uploadProgramFiles` definition after `programStorage` initialization

- Prevents ReferenceError from using undefined `programStorage` variable

- Fixes initialization order dependency in multer configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["uploadProgramFiles declaration"] -->|moved after| B["programStorage definition"]
  B -->|provides storage config to| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.js</strong><dd><code>Reorder multer storage initialization dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server.js

<ul><li>Relocated <code>uploadProgramFiles</code> constant definition from line 59 to line <br>85<br> <li> Moved declaration to occur after <code>programStorage</code> multer.diskStorage <br>initialization<br> <li> Resolves ReferenceError caused by using undefined <code>programStorage</code> <br>variable</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/80/files#diff-79f4c7cdc0b026f6e556196f5911a449157807cffdb3f9d33f0b5404b4ffc2f3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

