### PR TITLE
Fix inline video click pause behavior

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5921,7 +5921,9 @@
 
           let hasPlaybackError = false;
 
-          videoElement.addEventListener("click", () => {
+          videoElement.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
             if (videoElement.paused) {
               videoElement.play().catch(() => {});
             } else {


### PR DESCRIPTION
### **User description**
## Summary
- stop the clip grid video click handler from triggering native double toggling
- ensure clicking the video surface cleanly toggles between play and pause

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940810fa664832798102b36e8059a0b)


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent native double-toggle behavior on video click

- Add event handling to cleanly control play/pause

- Stop event propagation to parent elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Video click event"] --> B["preventDefault()"]
  B --> C["stopPropagation()"]
  C --> D["Toggle play/pause state"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.html</strong><dd><code>Add event handling to video click listener</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

public/index.html

<ul><li>Added <code>event</code> parameter to video click listener<br> <li> Added <code>event.preventDefault()</code> to block default behavior<br> <li> Added <code>event.stopPropagation()</code> to prevent event bubbling<br> <li> Maintains existing play/pause toggle logic</ul>


</details>


  </td>
  <td><a href="https://github.com/AntalJozsefminiszterur88/UMKGL-HUB-WEBOLDAL/pull/93/files#diff-c2cc24bc9001b11b6add48a4cd8f893d5d6c6e4d1bd254158bd14ab997f552cd">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

