### PR TITLE
Fix video modal layout sizing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2493,11 +2493,13 @@
       }
 
       .video-modal__nav-wrapper {
+        position: absolute;
+        inset: 0;
         display: flex;
         align-items: center;
         justify-content: center;
         gap: 0.75rem;
-        width: 100%;
+        pointer-events: none;
       }
 
       @media (max-width: 960px) {
@@ -2527,10 +2529,12 @@
         }
 
         .video-modal__nav-wrapper {
+          position: static;
           display: flex;
           gap: 0.75rem;
           width: 100%;
           justify-content: center;
+          pointer-events: auto;
         }
       }
     </style>


### PR DESCRIPTION
## Summary
- prevent video modal navigation wrapper from shrinking the video player
- keep mobile navigation controls unaffected while desktop overlay spans full modal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940aca7af388327829de42574a1e28f)