### PR TITLE
Fix upload counter update and remove duplicate handling block

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1070,14 +1070,8 @@ app.post('/upload', authenticateToken, loadUserUploadSettings, (req, res, next) 
             }
         }
 
-        await client.query('UPDATE users SET upload_count = upload_count + $1 WHERE id = $2', [newFiles.length, uploaderId]);
+        await client.query('UPDATE users SET upload_count = upload_count + $1 WHERE id = $2', [filesToProcess.length, uploaderId]);
         await client.query('COMMIT');
-        if (duplicateFiles.length) {
-            const duplicateList = duplicateFiles.map(({ sanitizedOriginalName }) => sanitizedOriginalName).join(', ');
-            return res.status(207).json({
-                message: `A videók feltöltése részben sikerült. A következő nevű klipeket kihagytuk, mert már léteznek: ${duplicateList}.`,
-            });
-        }
 
         res.status(201).json({ message: 'Videók sikeresen feltöltve.' });
     } catch (err) {


### PR DESCRIPTION
## Summary
- correct upload count increment to use filesToProcess length instead of undefined variable
- remove unused duplicate file response handling from upload endpoint

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ad8601dc83278d8480f9e7765fb0)