### PR TITLE
Prevent video modal nav buttons from moving on hover

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2447,13 +2447,12 @@
         line-height: 1;
         cursor: pointer;
         pointer-events: auto;
-        transition: background 0.2s ease, transform 0.2s ease;
+        transition: background 0.2s ease;
       }
 
       .video-modal__nav:hover,
       .video-modal__nav:focus-visible {
         background: rgba(255, 255, 255, 0.2);
-        transform: scale(1.04);
         outline: none;
       }
 


### PR DESCRIPTION
## Summary
- remove the hover scale transform from video modal navigation buttons so they no longer shift position
- keep a simple background highlight for hover and focus feedback

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940af95f1dc8327b9e0752c2d658b41)