### PR TITLE
Adjust UMKGL HUB header sizing and navigation links

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="hu">
   <head>
     <meta charset="UTF-8" />
-    <title>UMGKL HUB</title>
+    <title>UMKGL HUB</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="program_icons/oldal_logo.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -821,7 +821,7 @@
 
       h1 {
         margin-top: 1rem;
-        font-size: 2.5rem;
+        font-size: 56px;
         color: var(--accent);
       }
 
@@ -840,6 +840,7 @@
         color: var(--text-primary);
         text-decoration: none;
         padding: 0.5rem 1rem;
+        font-size: 1.1rem;
         border-radius: 4px;
         transition: background 0.2s;
       }
@@ -2547,7 +2548,7 @@
   </head>
   <body>
     <header>
-      <h1>UMGKL HUB</h1>
+      <h1>UMKGL HUB</h1>
       <nav>
         <a href="#home" data-section="home" class="active">Főoldal</a>
         <a
@@ -3117,7 +3118,7 @@
     </div>
 
     <footer>
-      <p>© 2025 UMGKL HUB Minden jog fenntartva</p>
+      <p>© 2025 UMKGL HUB Minden jog fenntartva</p>
     </footer>
 
     <div id="videoPlayerModal" class="video-modal" aria-hidden="true">


### PR DESCRIPTION
## Summary
- set the UMKGL HUB heading to 56px and align branding text
- enlarge navigation link font size to make subpage options 10% bigger

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940b19985848327bd825bdf1a5c0aff)