### PR TITLE
Make uploaded hashes endpoint public

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -919,7 +919,7 @@ app.get('/api/videos/get-uploaded-titles', authenticateToken, ensureClipViewPerm
     }
 });
 
-app.get('/api/videos/get-uploaded-hashes', authenticateToken, ensureClipViewPermission, async (_req, res) => {
+app.get('/api/videos/get-uploaded-hashes', async (_req, res) => {
     try {
         const { rows } = await db.query('SELECT file_hash FROM videos WHERE file_hash IS NOT NULL');
         const hashes = (rows || []).map((row) => row.file_hash).filter(Boolean);


### PR DESCRIPTION
## Summary
- remove authentication middleware from `/api/videos/get-uploaded-hashes` to allow unauthenticated access

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941a3501fac832797067bbdcc4ce607)