### PR TITLE
Add thumbnail generation and backfill endpoint

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -69,6 +69,9 @@ async function initializeDatabase() {
       'ALTER TABLE videos ADD COLUMN IF NOT EXISTS file_hash TEXT UNIQUE'
     );
     await client.query(
+      'ALTER TABLE videos ADD COLUMN IF NOT EXISTS thumbnail_filename TEXT'
+    );
+    await client.query(
       'ALTER TABLE videos DROP CONSTRAINT IF EXISTS videos_original_name_key'
     );
 


### PR DESCRIPTION
## Summary
- add database support for storing generated video thumbnail filenames
- generate thumbnails during upload and expose thumbnail data through the videos API
- add a public admin endpoint to backfill missing thumbnails on existing videos

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d496c4d483278313c9ffad6e6343)