### PR TITLE
Use GET for missing thumbnail generation endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1009,7 +1009,7 @@ app.get('/api/videos/get-uploaded-hashes', async (_req, res) => {
     }
 });
 
-app.post('/api/admin/generate-missing-thumbnails', async (_req, res) => {
+app.get('/api/admin/generate-missing-thumbnails', async (_req, res) => {
     try {
         const { rows } = await db.query('SELECT id, filename FROM videos WHERE thumbnail_filename IS NULL');
         const results = [];


### PR DESCRIPTION
## Summary
- switch the missing thumbnail generation admin endpoint to respond to GET requests

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941d8c8823083278a96bc2e79d28ede)