### PR TITLE
Fix 720p path handling and add rescue admin endpoint

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6639,7 +6639,12 @@
         const has720pAvailable = Number(video?.has_720p) === 1 || video?.has_720p === true || video?.has_720p === "1";
 
         if (normalizedQuality === "720p" && has720pAvailable && video?.filename) {
-          return { src: `/uploads/${appendQualitySuffix(video.filename, "_720p")}`, has720pAvailable, prefers720p: true };
+          const hasOriginalFolder = video.filename.includes("/eredeti/");
+          const targetPath = hasOriginalFolder
+            ? appendQualitySuffix(video.filename.replace("/eredeti/", "/720p/"), "_720p")
+            : appendQualitySuffix(video.filename, "_720p");
+
+          return { src: `/uploads/${targetPath}`, has720pAvailable, prefers720p: true };
         }
 
         return { src: baseSource, has720pAvailable, prefers720p: normalizedQuality === "720p" };


### PR DESCRIPTION
## Summary
- update preferred 720p video path generation to use the new `klippek/720p` structure when the original folder is present
- add an admin rescue endpoint that moves orphaned 720p files from legacy clip folders into their correct locations and cleans up empty directories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f9b955108327851112a5cdc16be3)