### PR TITLE
Add popup admin clip list window

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5496,6 +5496,18 @@
       });
     }
 
+    async function fetchAdminClips() {
+      const response = await fetch("/api/admin/clips", { headers: buildAuthHeaders() });
+      const data = await response.json().catch(() => null);
+
+      if (!response.ok) {
+        const message = data && data.message ? data.message : "Nem sikerült lekérdezni a klipeket.";
+        throw new Error(message);
+      }
+
+      return Array.isArray(data) ? data : [];
+    }
+
     async function loadAdminClips() {
       setClipListMessage("Klipek betöltése folyamatban...");
       if (adminClipList) {
@@ -5503,15 +5515,8 @@
       }
 
       try {
-        const response = await fetch("/api/admin/clips", { headers: buildAuthHeaders() });
-        const data = await response.json().catch(() => null);
-
-        if (!response.ok) {
-          const message = data && data.message ? data.message : "Nem sikerült lekérdezni a klipeket.";
-          throw new Error(message);
-        }
-
-        renderAdminClipList(Array.isArray(data) ? data : []);
+        const clips = await fetchAdminClips();
+        renderAdminClipList(clips);
       } catch (error) {
         console.error("Klip lista betöltési hiba:", error);
         setClipListMessage(error.message || "Nem sikerült betölteni a klipeket.");
@@ -5557,6 +5562,248 @@
       } finally {
         if (button) {
           button.disabled = false;
+        }
+      }
+    }
+
+    function createClipListWindowLayout(clipWindow) {
+      const doc = clipWindow.document;
+
+      doc.title = "Klipek listája";
+      doc.body.innerHTML = `
+        <style>
+          body {
+            font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #f3f4f6;
+            color: #111827;
+            margin: 0;
+            padding: 20px;
+          }
+
+          .clip-window {
+            max-width: 1200px;
+            margin: 0 auto;
+            font-size: 14px;
+          }
+
+          .clip-window h1 {
+            margin: 0 0 6px;
+            font-size: 20px;
+          }
+
+          .clip-window__subtitle {
+            margin: 0 0 16px;
+            color: #4b5563;
+          }
+
+          .clip-window__status {
+            margin-bottom: 10px;
+            color: #374151;
+          }
+
+          .clip-window__table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+          }
+
+          .clip-window__table thead {
+            background: #e5e7eb;
+          }
+
+          .clip-window__table th,
+          .clip-window__table td {
+            padding: 8px 10px;
+            border-bottom: 1px solid #e5e7eb;
+            text-align: left;
+            vertical-align: top;
+          }
+
+          .clip-window__table th {
+            font-weight: 600;
+          }
+
+          .clip-window__table tr:last-child td {
+            border-bottom: none;
+          }
+
+          .clip-window__delete {
+            background: #dc2626;
+            color: #fff;
+            border: none;
+            padding: 6px 10px;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 13px;
+            transition: background 0.2s ease;
+          }
+
+          .clip-window__delete:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+          }
+
+          .clip-window__delete:not(:disabled):hover {
+            background: #b91c1c;
+          }
+        </style>
+        <div class="clip-window">
+          <h1>Feltöltött klipek</h1>
+          <p class="clip-window__subtitle">Egyszerű, áttekinthető lista a klipjeidről.</p>
+          <div id="clipWindowStatus" class="clip-window__status">Klipek betöltése folyamatban...</div>
+          <div id="clipWindowTable"></div>
+        </div>
+      `;
+
+      return {
+        doc,
+        statusEl: doc.getElementById("clipWindowStatus"),
+        tableContainer: doc.getElementById("clipWindowTable"),
+      };
+    }
+
+    async function handleClipDeleteFromWindow(clipId, rowElement, button, clipName, statusEl) {
+      if (!Number.isFinite(clipId)) {
+        return;
+      }
+
+      const confirmed = window.confirm(`Biztosan törlöd a(z) "${clipName || "klip"}" elemet? A törlés végleges.`);
+      if (!confirmed) {
+        return;
+      }
+
+      if (button) {
+        button.disabled = true;
+      }
+
+      try {
+        const response = await fetch(`/api/videos/${clipId}`, {
+          method: "DELETE",
+          headers: buildAuthHeaders(),
+        });
+
+        const data = await response.json().catch(() => null);
+        if (!response.ok) {
+          const message = data && data.message ? data.message : "Nem sikerült törölni a klipet.";
+          throw new Error(message);
+        }
+
+        if (rowElement && rowElement.parentElement) {
+          rowElement.parentElement.removeChild(rowElement);
+        }
+
+        const remainingRows = rowElement?.parentElement?.children?.length || 0;
+        if (remainingRows === 0 && statusEl) {
+          statusEl.textContent = "Nincs feltöltött klip.";
+        }
+      } catch (error) {
+        console.error("Klip törlési hiba:", error);
+        alert(error.message || "Nem sikerült törölni a klipet.");
+      } finally {
+        if (button) {
+          button.disabled = false;
+        }
+      }
+    }
+
+    function renderClipTableInWindow(doc, tableContainer, statusEl, clips) {
+      if (!tableContainer) {
+        return;
+      }
+
+      tableContainer.innerHTML = "";
+
+      if (!Array.isArray(clips) || clips.length === 0) {
+        if (statusEl) {
+          statusEl.textContent = "Nincs feltöltött klip.";
+        }
+        return;
+      }
+
+      if (statusEl) {
+        statusEl.textContent = "";
+      }
+
+      const table = doc.createElement("table");
+      table.className = "clip-window__table";
+
+      const thead = doc.createElement("thead");
+      const headerRow = doc.createElement("tr");
+      ["Szép cím", "Adatbázis cím", "Fájlméret", "Feltöltési idő", "Egyéb", "Művelet"].forEach((text) => {
+        const th = doc.createElement("th");
+        th.textContent = text;
+        headerRow.appendChild(th);
+      });
+      thead.appendChild(headerRow);
+      table.appendChild(thead);
+
+      const tbody = doc.createElement("tbody");
+
+      clips.forEach((clip) => {
+        const row = doc.createElement("tr");
+
+        const prettyTitle = doc.createElement("td");
+        prettyTitle.textContent = clip.original_name || "Ismeretlen név";
+        row.appendChild(prettyTitle);
+
+        const dbTitle = doc.createElement("td");
+        dbTitle.textContent = clip.filename || "-";
+        row.appendChild(dbTitle);
+
+        const sizeCell = doc.createElement("td");
+        sizeCell.textContent = formatFileSize(Number(clip.sizeBytes));
+        row.appendChild(sizeCell);
+
+        const uploadedCell = doc.createElement("td");
+        uploadedCell.textContent = formatDateTime(clip.uploaded_at);
+        row.appendChild(uploadedCell);
+
+        const extraCell = doc.createElement("td");
+        extraCell.textContent = clip.uploader ? `Feltöltő: ${clip.uploader}` : "-";
+        row.appendChild(extraCell);
+
+        const actionCell = doc.createElement("td");
+        const deleteBtn = doc.createElement("button");
+        deleteBtn.type = "button";
+        deleteBtn.textContent = "Törlés";
+        deleteBtn.className = "clip-window__delete";
+        deleteBtn.addEventListener("click", () => {
+          handleClipDeleteFromWindow(clip.id, row, deleteBtn, clip.original_name, statusEl);
+        });
+        actionCell.appendChild(deleteBtn);
+        row.appendChild(actionCell);
+
+        tbody.appendChild(row);
+      });
+
+      table.appendChild(tbody);
+      tableContainer.appendChild(table);
+    }
+
+    async function openClipListWindow() {
+      if (!isUserLoggedIn()) {
+        alert("Nincs érvényes hitelesítés.");
+        return;
+      }
+
+      const clipWindow = window.open("", "_blank");
+      if (!clipWindow || clipWindow.closed) {
+        alert("Nem sikerült megnyitni az új ablakot.");
+        return;
+      }
+
+      const { doc, statusEl, tableContainer } = createClipListWindowLayout(clipWindow);
+
+      try {
+        const clips = await fetchAdminClips();
+        renderClipTableInWindow(doc, tableContainer, statusEl, clips);
+      } catch (error) {
+        console.error("Klip lista betöltési hiba:", error);
+        if (statusEl) {
+          statusEl.textContent = error.message || "Nem sikerült betölteni a klipeket.";
         }
       }
     }
@@ -5676,17 +5923,7 @@
 
     if (loadClipsBtn) {
       loadClipsBtn.addEventListener("click", () => {
-        if (!adminClipsPanel) {
-          return;
-        }
-
-        const shouldShow = adminClipsPanel.style.display === "none" || adminClipsPanel.style.display === "";
-        adminClipsPanel.style.display = shouldShow ? "block" : "none";
-        loadClipsBtn.textContent = shouldShow ? "Lista frissítése" : "Klip lista megnyitása";
-
-        if (shouldShow) {
-          loadAdminClips();
-        }
+        openClipListWindow();
       });
     }
 


### PR DESCRIPTION
## Summary
- add shared admin clip fetching helper
- open the admin clip list in a new window with a compact table layout
- include deletion controls for each clip entry in the popup view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69470eda92548327abe23f6e29029e6b)