### PR TITLE
Optimize original uploads before 720p processing

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1850,10 +1850,23 @@ app.post('/upload', authenticateToken, ensureClipViewPermission, loadUserUploadS
         if (videosForTranscode.length) {
             setImmediate(() => {
                 videosForTranscode.forEach(({ videoId, filePath, outputDir, originalFilename }) => {
-                    processVideoFor720p(videoId, filePath, outputDir, originalFilename)
-                        .catch((err) => {
+                    (async () => {
+                        try {
+                            try {
+                                const optimized = await optimizeVideoForFaststart(filePath);
+
+                                if (!optimized) {
+                                    console.warn(`Nem sikerült optimalizálni a(z) ${videoId} videót faststart-tal.`);
+                                }
+                            } catch (optimizeErr) {
+                                console.error(`Hiba a(z) ${videoId} videó faststart optimalizálása során:`, optimizeErr);
+                            }
+
+                            await processVideoFor720p(videoId, filePath, outputDir, originalFilename);
+                        } catch (err) {
                             console.error(`Hiba a(z) ${videoId} videó 720p konvertálása során:`, err);
-                        });
+                        }
+                    })();
                 });
             });
         }


### PR DESCRIPTION
## Summary
- optimize original uploaded videos with faststart during background processing
- ensure faststart failures do not block 720p transcoding and log outcomes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69471410b10c832785575ceb8c14bf30)