### PR TITLE
Implement queued video processing workflow

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -63,6 +63,7 @@ async function initializeDatabase() {
         uploader_id INTEGER NOT NULL,
         uploaded_at TIMESTAMPTZ DEFAULT NOW(),
         has_720p INTEGER DEFAULT 0,
+        processing_status TEXT DEFAULT 'done',
         FOREIGN KEY (uploader_id) REFERENCES users(id)
       )
     `);
@@ -81,6 +82,9 @@ async function initializeDatabase() {
     );
     await client.query(
       'ALTER TABLE videos ADD COLUMN IF NOT EXISTS has_720p INTEGER DEFAULT 0'
+    );
+    await client.query(
+      "ALTER TABLE videos ADD COLUMN IF NOT EXISTS processing_status TEXT DEFAULT 'done'"
     );
 
     await client.query(`


### PR DESCRIPTION
## Summary
- add processing_status tracking for videos and migrate database schema
- introduce serialized video processing queue and enqueue uploads/transcode-missing tasks
- add cleanup endpoint for zero-byte mp4 files and ensure ffmpeg faststart flags remain in place

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69471f70be108327914e42a94e41ca33)