### PR TITLE
Persist clip filter selection

### DIFF
--- a/public/clips.html
+++ b/public/clips.html
@@ -369,6 +369,8 @@
         const tableContainer = document.getElementById("clipWindowTable");
         const variantSelect = document.getElementById("clipWindowVariant");
         const countEl = document.getElementById("clipWindowCount");
+        const VARIANT_STORAGE_KEY = "clipWindowVariant";
+        const VALID_VARIANTS = ["original", "720p", "other"];
 
         if (!isUserLoggedIn()) {
           alert("Nincs érvényes hitelesítés. Jelentkezz be, hogy lásd a klipeket.");
@@ -398,14 +400,30 @@
           }
         };
 
+        const getInitialVariant = () => {
+          const stored = localStorage.getItem(VARIANT_STORAGE_KEY);
+          if (stored && VALID_VARIANTS.includes(stored)) {
+            return stored;
+          }
+          return "original";
+        };
+
+        const initialVariant = getInitialVariant();
+
         if (variantSelect) {
+          variantSelect.value = initialVariant;
           variantSelect.addEventListener("change", (event) => {
             const value = event.target?.value || "original";
+            if (VALID_VARIANTS.includes(value)) {
+              localStorage.setItem(VARIANT_STORAGE_KEY, value);
+            } else {
+              localStorage.removeItem(VARIANT_STORAGE_KEY);
+            }
             loadVariant(value);
           });
         }
 
-        await loadVariant(variantSelect?.value || "original");
+        await loadVariant(initialVariant);
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- add localStorage-backed persistence for the clip filter variant selection
- default to the last used variant when reloading the clips page
- validate stored filter values to keep the UI consistent


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69473d2390ac8327801429655f2b79f0)