### PR TITLE
Create unified video management page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6128,15 +6128,17 @@
       adminNavBtn.addEventListener("click", loadAdminPanel);
     }
 
+    const VIDEO_MANAGEMENT_PATH = "/video-kezeles-felulet.html";
+
     if (loadClipsBtn) {
       loadClipsBtn.addEventListener("click", () => {
-        window.open("/clips.html", "_blank");
+        window.open(VIDEO_MANAGEMENT_PATH, "_blank");
       });
     }
 
     if (processingStatusBtn) {
       processingStatusBtn.addEventListener("click", () => {
-        window.open("/processing-status.html", "_blank");
+        window.open(VIDEO_MANAGEMENT_PATH, "_blank");
       });
     }
 

--- a/public/video-kezeles-felulet.html
+++ b/public/video-kezeles-felulet.html
@@ -1,0 +1,873 @@
+<!DOCTYPE html>
+<html lang="hu">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Videó kezelés felület</title>
+    <link rel="icon" type="image/png" href="program_icons/oldal_logo.png" />
+    <style>
+      :root {
+        --bg: #f3f4f6;
+        --card: #fff;
+        --text: #111827;
+        --muted: #4b5563;
+        --border: #d1d5db;
+        --accent: #2563eb;
+        --accent-strong: #1d4ed8;
+        --danger: #dc2626;
+        --shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+      }
+
+      body {
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        margin: 0;
+        padding: 20px;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 18px;
+        color: var(--accent);
+        text-decoration: none;
+        font-weight: 600;
+      }
+
+      .back-link span {
+        font-size: 16px;
+      }
+
+      .manager {
+        max-width: 1250px;
+        margin: 0 auto;
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+      }
+
+      .manager__header {
+        background: var(--card);
+        border-radius: 14px;
+        padding: 18px;
+        box-shadow: var(--shadow);
+      }
+
+      .manager__title {
+        margin: 0 0 6px;
+        font-size: 24px;
+      }
+
+      .manager__subtitle {
+        margin: 0;
+        color: var(--muted);
+      }
+
+      .manager__tabs {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-top: 14px;
+      }
+
+      .manager__tab {
+        background: #e5e7eb;
+        border: 1px solid #d1d5db;
+        color: var(--text);
+        padding: 10px 14px;
+        border-radius: 10px;
+        cursor: pointer;
+        font-size: 14px;
+        transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+      }
+
+      .manager__tab:hover {
+        background: #dbeafe;
+        color: var(--accent);
+        border-color: #bfdbfe;
+      }
+
+      .manager__tab--active {
+        background: var(--accent);
+        color: #fff;
+        border-color: var(--accent);
+      }
+
+      .manager__content {
+        background: var(--card);
+        border-radius: 14px;
+        padding: 18px;
+        box-shadow: var(--shadow);
+      }
+
+      .manager__section {
+        display: none;
+      }
+
+      .manager__section--active {
+        display: block;
+      }
+
+      /* Clip list styles */
+      .clip-window h2 {
+        margin: 0 0 6px;
+        font-size: 20px;
+      }
+
+      .clip-window__subtitle {
+        margin: 0 0 16px;
+        color: var(--muted);
+      }
+
+      .clip-window__controls {
+        display: flex;
+        gap: 0.75rem;
+        align-items: center;
+        margin-bottom: 12px;
+        flex-wrap: wrap;
+      }
+
+      .clip-window__select {
+        padding: 6px 10px;
+        border-radius: 8px;
+        border: 1px solid var(--border);
+        background: #f9fafb;
+        min-width: 220px;
+        font-size: 14px;
+      }
+
+      .clip-window__count {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .clip-window__status {
+        margin-bottom: 10px;
+        color: #374151;
+      }
+
+      .clip-window__table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #fff;
+        border-radius: 8px;
+        overflow: hidden;
+        box-shadow: var(--shadow);
+      }
+
+      .clip-window__table thead {
+        background: #e5e7eb;
+      }
+
+      .clip-window__table th,
+      .clip-window__table td {
+        padding: 8px 10px;
+        border-bottom: 1px solid #e5e7eb;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      .clip-window__table th {
+        font-weight: 600;
+      }
+
+      .clip-window__table tr:last-child td {
+        border-bottom: none;
+      }
+
+      .clip-window__name {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .clip-window__name-text {
+        flex: 1;
+      }
+
+      .clip-window__edit {
+        border: none;
+        background: none;
+        cursor: pointer;
+        color: var(--accent);
+        padding: 4px;
+        border-radius: 6px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .clip-window__edit:hover,
+      .clip-window__edit:focus-visible {
+        background: #e0e7ff;
+        outline: none;
+      }
+
+      .clip-window__delete {
+        background: var(--danger);
+        color: #fff;
+        border: none;
+        padding: 6px 10px;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: background 0.2s ease;
+      }
+
+      .clip-window__delete:hover {
+        background: #b91c1c;
+      }
+
+      /* Processing styles */
+      .process-window h2 {
+        margin: 0 0 10px;
+        font-size: 20px;
+      }
+
+      .process-window__subtitle {
+        margin: 0 0 16px;
+        color: var(--muted);
+      }
+
+      .process-window__status {
+        margin: 0 0 16px;
+        color: var(--text);
+        font-weight: 600;
+      }
+
+      .process-window__card {
+        background: #fff;
+        border-radius: 10px;
+        padding: 16px;
+        box-shadow: var(--shadow);
+        margin-bottom: 14px;
+      }
+
+      .process-window__meta {
+        margin: 6px 0;
+        color: var(--muted);
+      }
+
+      .process-window__section-title {
+        margin: 16px 0 10px;
+        font-size: 18px;
+      }
+
+      .process-window__queue {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .process-window__empty {
+        color: #6b7280;
+        font-style: italic;
+      }
+
+      .process-window__refresh {
+        background: var(--accent);
+        color: #fff;
+        border: none;
+        padding: 10px 14px;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 14px;
+        transition: background 0.2s ease;
+      }
+
+      .process-window__refresh:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      .process-window__refresh:hover:not(:disabled) {
+        background: var(--accent-strong);
+      }
+
+      .process-window__header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex-wrap: wrap;
+        justify-content: space-between;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="/" class="back-link"><span>←</span> Vissza a főoldalra</a>
+    <div class="manager">
+      <div class="manager__header">
+        <h1 class="manager__title">Videó kezelés felület</h1>
+        <p class="manager__subtitle">Klipek áttekintése és a feldolgozás követése egyetlen oldalon.</p>
+        <div class="manager__tabs">
+          <button class="manager__tab manager__tab--active" data-target="clipsSection" type="button">Klip lista</button>
+          <button class="manager__tab" data-target="processingSection" type="button">Feldolgozási állapot</button>
+        </div>
+      </div>
+
+      <div class="manager__content">
+        <section id="clipsSection" class="manager__section manager__section--active">
+          <div class="clip-window">
+            <h2>Feltöltött klipek</h2>
+            <p class="clip-window__subtitle">Egyszerű, áttekinthető lista a klipjeidről.</p>
+            <div class="clip-window__controls">
+              <label for="clipWindowVariant">Megjelenített fájlok</label>
+              <select id="clipWindowVariant" class="clip-window__select">
+                <option value="original">Eredeti videók</option>
+                <option value="720p">720p videók</option>
+                <option value="other">Egyéb fájlok</option>
+              </select>
+              <span id="clipWindowCount" class="clip-window__count"></span>
+            </div>
+            <div id="clipWindowStatus" class="clip-window__status">Klipek betöltése folyamatban...</div>
+            <div id="clipWindowTable"></div>
+          </div>
+        </section>
+
+        <section id="processingSection" class="manager__section">
+          <div class="process-window">
+            <div class="process-window__header">
+              <div>
+                <h2>Feldolgozási állapot</h2>
+                <p class="process-window__subtitle">Ellenőrizd az aktuális és sorban álló fájlokat.</p>
+              </div>
+              <button id="refreshProcessing" class="process-window__refresh" type="button">Frissítés</button>
+            </div>
+            <p id="processingStatusText" class="process-window__status">Állapot betöltése folyamatban...</p>
+            <div class="process-window__card" id="currentProcessing"></div>
+            <h3 class="process-window__section-title">Várólista <span id="processingQueueCount"></span></h3>
+            <ul class="process-window__queue" id="processingQueue"></ul>
+          </div>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      const SESSION_KEYS = {
+        token: "token",
+        username: "username",
+        isAdmin: "isAdmin",
+        canTransfer: "canTransfer",
+        canViewClips: "canViewClips",
+        profilePictureFilename: "profilePictureFilename",
+      };
+
+      function getStoredToken() {
+        return localStorage.getItem(SESSION_KEYS.token);
+      }
+
+      function isUserLoggedIn() {
+        return !!getStoredToken();
+      }
+
+      function isAdminUser() {
+        return localStorage.getItem(SESSION_KEYS.isAdmin) === "true";
+      }
+
+      function buildAuthHeaders() {
+        const token = getStoredToken();
+        if (!token) {
+          return {};
+        }
+        return {
+          Authorization: `Bearer ${token}`,
+        };
+      }
+
+      function formatFileSize(size) {
+        if (!Number.isFinite(size)) {
+          return "Ismeretlen";
+        }
+        if (size >= 1024 * 1024) {
+          return `${(size / (1024 * 1024)).toFixed(2)} MB`;
+        }
+        if (size >= 1024) {
+          return `${(size / 1024).toFixed(2)} KB`;
+        }
+        return `${size} B`;
+      }
+
+      function formatDateTime(value) {
+        if (!value) {
+          return "Ismeretlen dátum";
+        }
+
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          return "Ismeretlen dátum";
+        }
+
+        return date.toLocaleString("hu-HU", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+
+      async function fetchAdminClips(variant) {
+        const params = new URLSearchParams();
+        if (variant) {
+          params.set("type", variant);
+        }
+
+        const url = params.toString() ? `/api/admin/clips?${params.toString()}` : "/api/admin/clips";
+        const response = await fetch(url, { headers: buildAuthHeaders() });
+        const data = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          const message = data && data.message ? data.message : "Nem sikerült lekérdezni a klipeket.";
+          throw new Error(message);
+        }
+
+        const items = Array.isArray(data?.items) ? data.items : Array.isArray(data) ? data : [];
+        const total = Number.isFinite(data?.total) ? data.total : items.length;
+
+        return { items, total };
+      }
+
+      async function handleClipDelete(clipId, rowElement, button, clipName, statusEl) {
+        if (!Number.isFinite(clipId)) {
+          return;
+        }
+
+        const confirmed = window.confirm(`Biztosan törlöd a(z) "${clipName || "klip"}" elemet? A törlés végleges.`);
+        if (!confirmed) {
+          return;
+        }
+
+        if (button) {
+          button.disabled = true;
+        }
+
+        try {
+          const response = await fetch(`/api/videos/${clipId}`, {
+            method: "DELETE",
+            headers: buildAuthHeaders(),
+          });
+
+          const data = await response.json().catch(() => null);
+          if (!response.ok) {
+            const message = data && data.message ? data.message : "Nem sikerült törölni a klipet.";
+            throw new Error(message);
+          }
+
+          if (rowElement && rowElement.parentElement) {
+            rowElement.parentElement.removeChild(rowElement);
+          }
+
+          if (statusEl) {
+            statusEl.textContent = data?.message || "A klip törlése sikeres volt.";
+          }
+        } catch (error) {
+          console.error("Klip törlési hiba:", error);
+          if (statusEl) {
+            statusEl.textContent = error.message || "Nem sikerült törölni a klipet.";
+          }
+        } finally {
+          if (button) {
+            button.disabled = false;
+          }
+        }
+      }
+
+      async function handleClipTitleEdit(clip, nameTextEl, statusEl) {
+        const currentTitle = clip.original_name || "Ismeretlen";
+        const updatedTitle = window.prompt("Add meg az új klipcímet:", currentTitle);
+
+        if (updatedTitle === null) {
+          return;
+        }
+
+        const normalizedTitle = updatedTitle.trim();
+        if (!normalizedTitle || normalizedTitle === currentTitle) {
+          return;
+        }
+
+        try {
+          const response = await fetch(`/api/videos/${clip.id}/title`, {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+              ...buildAuthHeaders(),
+            },
+            body: JSON.stringify({ title: normalizedTitle }),
+          });
+
+          const data = await response.json().catch(() => null);
+          if (!response.ok) {
+            const message = data?.message || "Nem sikerült frissíteni a klip címét.";
+            throw new Error(message);
+          }
+
+          const newTitle = data?.original_name || normalizedTitle;
+          clip.original_name = newTitle;
+          if (nameTextEl) {
+            nameTextEl.textContent = newTitle;
+          }
+          if (statusEl) {
+            statusEl.textContent = data?.message || "A klip címe frissült.";
+          }
+        } catch (error) {
+          console.error("Klip cím módosítási hiba:", error);
+          if (statusEl) {
+            statusEl.textContent = error.message || "Nem sikerült frissíteni a klip címét.";
+          }
+        }
+      }
+
+      function renderClipTable(statusEl, tableContainer, items, countEl, isAdmin) {
+        if (!tableContainer) {
+          return;
+        }
+
+        tableContainer.innerHTML = "";
+
+        if (!Array.isArray(items) || !items.length) {
+          const empty = document.createElement("p");
+          empty.className = "clip-window__status";
+          empty.textContent = "Nincs megjeleníthető klip.";
+          tableContainer.appendChild(empty);
+          if (statusEl) {
+            statusEl.textContent = "Nincs megjeleníthető klip.";
+          }
+          if (countEl) {
+            countEl.textContent = "(0 találat)";
+          }
+          return;
+        }
+
+        if (statusEl) {
+          statusEl.textContent = "";
+        }
+
+        const table = document.createElement("table");
+        table.className = "clip-window__table";
+
+        const thead = document.createElement("thead");
+        const headRow = document.createElement("tr");
+        ["Azonosító", "Fájlnév", "Méret", "Feltöltve", "Egyéb", "Művelet"].forEach((title) => {
+          const th = document.createElement("th");
+          th.textContent = title;
+          headRow.appendChild(th);
+        });
+        thead.appendChild(headRow);
+        table.appendChild(thead);
+
+        const tbody = document.createElement("tbody");
+        items.forEach((clip) => {
+          const row = document.createElement("tr");
+
+          const idCell = document.createElement("td");
+          idCell.textContent = clip.id ?? "-";
+          row.appendChild(idCell);
+
+          const nameCell = document.createElement("td");
+          nameCell.className = "clip-window__name";
+
+          const nameText = document.createElement("span");
+          nameText.className = "clip-window__name-text";
+          nameText.textContent = clip.original_name || "Ismeretlen";
+          nameCell.appendChild(nameText);
+
+          if (isAdmin) {
+            const editBtn = document.createElement("button");
+            editBtn.type = "button";
+            editBtn.className = "clip-window__edit";
+            editBtn.title = "Klip címének szerkesztése";
+            editBtn.textContent = "✏️";
+            editBtn.addEventListener("click", () => {
+              handleClipTitleEdit(clip, nameText, statusEl);
+            });
+            nameCell.appendChild(editBtn);
+          }
+
+          row.appendChild(nameCell);
+
+          const sizeCell = document.createElement("td");
+          sizeCell.textContent = formatFileSize(Number(clip.sizeBytes));
+          row.appendChild(sizeCell);
+
+          const uploadedCell = document.createElement("td");
+          uploadedCell.textContent = formatDateTime(clip.uploaded_at);
+          row.appendChild(uploadedCell);
+
+          const extraCell = document.createElement("td");
+          const extraParts = [];
+          if (clip.uploader) {
+            extraParts.push(`Feltöltő: ${clip.uploader}`);
+          }
+          if (clip.category === "720p") {
+            extraParts.push("Verzió: 720p");
+          } else if (clip.category === "other") {
+            extraParts.push("Típus: Egyéb fájl");
+          } else {
+            extraParts.push("Verzió: Eredeti");
+          }
+          extraCell.textContent = extraParts.length ? extraParts.join(" • ") : "-";
+          row.appendChild(extraCell);
+
+          const actionCell = document.createElement("td");
+          const deleteBtn = document.createElement("button");
+          deleteBtn.type = "button";
+          deleteBtn.textContent = "Törlés";
+          deleteBtn.className = "clip-window__delete";
+          deleteBtn.addEventListener("click", () => {
+            handleClipDelete(clip.id, row, deleteBtn, clip.original_name, statusEl);
+          });
+          actionCell.appendChild(deleteBtn);
+          row.appendChild(actionCell);
+
+          tbody.appendChild(row);
+        });
+
+        table.appendChild(tbody);
+        tableContainer.appendChild(table);
+
+        if (countEl) {
+          countEl.textContent = `(${items.length} találat)`;
+        }
+      }
+
+      function formatHungarianDate(value) {
+        if (!value) {
+          return "Ismeretlen";
+        }
+
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+          return "Ismeretlen";
+        }
+
+        return date.toLocaleString("hu-HU", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+
+      async function fetchProcessingStatus() {
+        const response = await fetch("/api/processing-status", {
+          headers: buildAuthHeaders(),
+        });
+
+        const data = await response.json().catch(() => null);
+        if (!response.ok) {
+          const message = data?.message || "Nem sikerült lekérdezni a feldolgozási állapotot.";
+          throw new Error(message);
+        }
+
+        return {
+          isProcessing: Boolean(data?.isProcessing),
+          currentTask: data?.currentTask || null,
+          pending: Array.isArray(data?.pending) ? data.pending : [],
+        };
+      }
+
+      function renderProcessingCard(container, item, titlePrefix) {
+        if (!container) {
+          return;
+        }
+
+        container.innerHTML = "";
+
+        if (!item) {
+          const empty = document.createElement("p");
+          empty.className = "process-window__empty";
+          empty.textContent = "Jelenleg nincs aktív feldolgozási feladat.";
+          container.appendChild(empty);
+          return;
+        }
+
+        const title = document.createElement("h3");
+        title.textContent = `${titlePrefix || "Fájl"}: ${item.original_name || item.filename || "Ismeretlen"}`;
+        container.appendChild(title);
+
+        const fileMeta = document.createElement("p");
+        fileMeta.className = "process-window__meta";
+        fileMeta.textContent = `Elérési út: ${item.filename || "-"}`;
+        container.appendChild(fileMeta);
+
+        const timeMeta = document.createElement("p");
+        timeMeta.className = "process-window__meta";
+        timeMeta.textContent = `Feltöltve: ${formatHungarianDate(item.uploaded_at)}`;
+        container.appendChild(timeMeta);
+
+        const statusMeta = document.createElement("p");
+        statusMeta.className = "process-window__meta";
+        statusMeta.textContent = `Státusz: ${item.processing_status || "ismeretlen"}`;
+        container.appendChild(statusMeta);
+      }
+
+      function renderQueue(doc, queueListEl, items) {
+        if (!queueListEl) {
+          return;
+        }
+
+        queueListEl.innerHTML = "";
+
+        if (!items || !items.length) {
+          const empty = doc.createElement("li");
+          empty.className = "process-window__empty";
+          empty.textContent = "Nincs várakozó fájl a sorban.";
+          queueListEl.appendChild(empty);
+          return;
+        }
+
+        items.forEach((item, index) => {
+          const li = doc.createElement("li");
+          li.className = "process-window__card";
+          renderProcessingCard(li, item, `#${index + 1}`);
+          queueListEl.appendChild(li);
+        });
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        const statusEl = document.getElementById("clipWindowStatus");
+        const tableContainer = document.getElementById("clipWindowTable");
+        const variantSelect = document.getElementById("clipWindowVariant");
+        const countEl = document.getElementById("clipWindowCount");
+        const refreshBtn = document.getElementById("refreshProcessing");
+        const processingStatusText = document.getElementById("processingStatusText");
+        const currentTaskEl = document.getElementById("currentProcessing");
+        const queueListEl = document.getElementById("processingQueue");
+        const queueCountEl = document.getElementById("processingQueueCount");
+        const tabs = document.querySelectorAll(".manager__tab");
+        const sections = document.querySelectorAll(".manager__section");
+        const VARIANT_STORAGE_KEY = "clipWindowVariant";
+        const VALID_VARIANTS = ["original", "720p", "other"];
+        const adminUser = isAdminUser();
+        let clipsLoaded = false;
+
+        if (!isUserLoggedIn()) {
+          alert("Nincs érvényes hitelesítés. Jelentkezz be, hogy lásd a klipeket és a feldolgozást.");
+          window.location.href = "/";
+          return;
+        }
+
+        const loadVariant = async (variant) => {
+          if (statusEl) {
+            statusEl.textContent = "Klipek betöltése folyamatban...";
+          }
+          if (countEl) {
+            countEl.textContent = "";
+          }
+          if (tableContainer) {
+            tableContainer.innerHTML = "";
+          }
+
+          try {
+            const { items } = await fetchAdminClips(variant);
+            renderClipTable(statusEl, tableContainer, items, countEl, adminUser);
+            clipsLoaded = true;
+          } catch (error) {
+            console.error("Klip lista betöltési hiba:", error);
+            if (statusEl) {
+              statusEl.textContent = error.message || "Nem sikerült betölteni a klipeket.";
+            }
+          }
+        };
+
+        const loadProcessingStatus = async () => {
+          if (processingStatusText) {
+            processingStatusText.textContent = "Állapot betöltése folyamatban...";
+          }
+          renderProcessingCard(currentTaskEl, null);
+          renderQueue(document, queueListEl, []);
+          if (queueCountEl) {
+            queueCountEl.textContent = "";
+          }
+
+          try {
+            const data = await fetchProcessingStatus();
+            if (processingStatusText) {
+              processingStatusText.textContent = data.isProcessing
+                ? "Egy fájl feldolgozása folyamatban."
+                : "Jelenleg nincs aktív feldolgozás.";
+            }
+
+            if (queueCountEl) {
+              queueCountEl.textContent = `Várakozó fájlok: ${data.pending.length}`;
+            }
+
+            renderProcessingCard(currentTaskEl, data.currentTask, "Aktív feldolgozás");
+            renderQueue(document, queueListEl, data.pending);
+          } catch (error) {
+            console.error("Feldolgozási állapot lekérdezési hiba:", error);
+            if (processingStatusText) {
+              processingStatusText.textContent = error.message || "Nem sikerült lekérdezni a feldolgozási állapotot.";
+            }
+          }
+        };
+
+        const getInitialVariant = () => {
+          const stored = localStorage.getItem(VARIANT_STORAGE_KEY);
+          if (stored && VALID_VARIANTS.includes(stored)) {
+            return stored;
+          }
+          return "original";
+        };
+
+        const switchSection = (targetId) => {
+          sections.forEach((section) => {
+            section.classList.toggle("manager__section--active", section.id === targetId);
+          });
+
+          tabs.forEach((tab) => {
+            const isActive = tab.dataset.target === targetId;
+            tab.classList.toggle("manager__tab--active", isActive);
+          });
+
+          if (targetId === "clipsSection" && !clipsLoaded) {
+            loadVariant(variantSelect?.value || "original");
+          }
+
+          if (targetId === "processingSection") {
+            loadProcessingStatus();
+          }
+        };
+
+        const initialVariant = getInitialVariant();
+
+        if (variantSelect) {
+          variantSelect.value = initialVariant;
+          variantSelect.addEventListener("change", (event) => {
+            const value = event.target?.value || "original";
+            if (VALID_VARIANTS.includes(value)) {
+              localStorage.setItem(VARIANT_STORAGE_KEY, value);
+            } else {
+              localStorage.removeItem(VARIANT_STORAGE_KEY);
+            }
+            loadVariant(value);
+          });
+        }
+
+        if (refreshBtn) {
+          refreshBtn.addEventListener("click", () => {
+            loadProcessingStatus();
+          });
+        }
+
+        tabs.forEach((tab) => {
+          tab.addEventListener("click", () => {
+            const targetId = tab.dataset.target;
+            switchSection(targetId);
+          });
+        });
+
+        loadVariant(initialVariant);
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new "Videó kezelés felület" page that merges the clip list and processing status tools
- provide a tabbed layout with shared authentication and refreshed styling for both views
- update the dashboard buttons to open the consolidated management page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69474240791c8327a31152b1452595cd)