### PR TITLE
Handle 720p clip playback fallback to original source

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7610,18 +7610,32 @@
         const rawTitle = activeVideo.original_name || activeVideo.filename;
         modalVideoTitle.textContent = cleanVideoTitle(rawTitle) || "Névtelen videó";
         const videoElements = videoGridContainer.querySelectorAll(".video-card video");
+        const originalSrc = `/uploads/${activeVideo.filename}`;
         const { src, has720pAvailable, prefers720p } = getPreferredVideoSource(
           activeVideo,
           currentVideoQuality
         );
         const sourceFromGrid = videoElements[currentVideoIndex]?.dataset?.src || "";
         const resolvedSource = src || sourceFromGrid;
+        const shouldFallbackToOriginal = prefers720p && resolvedSource && resolvedSource !== originalSrc;
 
         if (prefers720p && !has720pAvailable) {
           showClipToast("Ehhez a videóhoz nem érhető el 720p verzió.");
         }
 
-        modalVideoPlayer.src = resolvedSource || `/uploads/${activeVideo.filename}`;
+        if (shouldFallbackToOriginal) {
+          modalVideoPlayer.addEventListener(
+            "error",
+            () => {
+              modalVideoPlayer.src = originalSrc;
+              modalVideoPlayer.load();
+              modalVideoPlayer.play().catch(() => {});
+            },
+            { once: true }
+          );
+        }
+
+        modalVideoPlayer.src = resolvedSource || originalSrc;
         modalVideoPlayer.load();
         modalVideoPlayer.play().catch(() => {});
 


### PR DESCRIPTION
## Summary
- ensure the clip modal falls back to the original file when a preferred 720p source fails to load
- keep quality preference selection intact while preventing playback failures on 720p-only originals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481ebf5cc48327a7552ff328487d9e)