### PR TITLE
Tighten clip title edit button spacing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1131,8 +1131,8 @@
 
       .video-card__title-row {
         display: flex;
-        align-items: flex-start;
-        gap: 0.5rem;
+        align-items: center;
+        gap: 0.25rem;
       }
 
       .video-card__title {
@@ -1152,13 +1152,14 @@
         border: none;
         background: transparent;
         color: #9ca3af;
-        padding: 0.25rem;
-        border-radius: 8px;
+        padding: 0.15rem;
+        border-radius: 6px;
         cursor: pointer;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         line-height: 1;
+        font-size: 0.95rem;
       }
 
       .video-card__edit:hover,


### PR DESCRIPTION
## Summary
- adjust clip title row alignment to keep edit button closer to the text
- shrink edit button padding and font size for a compact icon-only look

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482237d97c83279718f6bb69624ffe)