### PR TITLE
Refine clip title edit control

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1189,7 +1189,7 @@
       .video-card__title-row {
         display: flex;
         align-items: center;
-        gap: 0.25rem;
+        gap: 0.2rem;
       }
 
       .video-card__title {
@@ -1209,7 +1209,8 @@
         border: none;
         background: transparent;
         color: #9ca3af;
-        padding: 0.15rem;
+        padding: 0;
+        margin-left: 0.2rem;
         border-radius: 6px;
         cursor: pointer;
         display: inline-flex;
@@ -1217,6 +1218,13 @@
         justify-content: center;
         line-height: 1;
         font-size: 0.95rem;
+        flex-shrink: 0;
+      }
+
+      .video-card__edit-icon {
+        width: 16px;
+        height: 16px;
+        display: block;
       }
 
       .video-card__edit:hover,
@@ -7698,7 +7706,14 @@
             editBtn.className = "video-card__edit";
             editBtn.title = "Klip címének szerkesztése";
             editBtn.setAttribute("aria-label", "Klip címének szerkesztése");
-            editBtn.textContent = "✏️";
+            editBtn.innerHTML = `
+              <svg class="video-card__edit-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path
+                  fill="currentColor"
+                  d="M3.6 16.8 3 21l4.2-.6L19.1 8.5 15.5 4.9 3.6 16.8Zm16.8-9.2c.2-.2.2-.5 0-.7l-2.3-2.3c-.2-.2-.5-.2-.7 0l-1.9 1.9 3 3 1.9-1.9Z"
+                />
+              </svg>
+            `;
             editBtn.addEventListener("click", (event) => {
               event.stopPropagation();
               handleClipTitleEdit(video, title);


### PR DESCRIPTION
## Summary
- replace the clip title edit emoji with a compact SVG pencil icon
- tighten spacing so the edit control sits closely after the title without stretching the card

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482592d86c83279891b869e9d6ad8f)