### PR TITLE
Fix clip table row spacing in video management interface

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5595,6 +5595,7 @@
           .clip-window__table {
             width: 100%;
             border-collapse: collapse;
+            border-spacing: 0;
             background: #fff;
             border-radius: 8px;
             overflow: hidden;

--- a/public/video-kezeles-felulet.html
+++ b/public/video-kezeles-felulet.html
@@ -155,6 +155,7 @@
       .clip-window__table {
         width: 100%;
         border-collapse: collapse;
+        border-spacing: 0;
         background: #fff;
         border-radius: 8px;
         overflow: hidden;


### PR DESCRIPTION
## Summary
- remove default table spacing on clip list tables to keep row separator lines continuous
- apply the spacing reset to both clip management windows for consistent rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948329cb0708327aa827dceef824e22)