### PR TITLE
Improve clip filters layout and tag dropdown interactions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1050,18 +1050,13 @@
       }
 
       .clip-filters {
-        margin: 1rem 0;
-        background: #1f2227;
-        padding: 1rem;
-        border-radius: 10px;
-        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
-      }
-
-      .filter-row {
         display: flex;
         flex-wrap: wrap;
+        gap: 15px;
         align-items: flex-end;
-        gap: 10px;
+        background: #1f2227;
+        padding: 15px;
+        border-radius: 8px;
       }
 
       .filter-group {
@@ -1076,69 +1071,63 @@
         color: #c9d1d9;
       }
 
-      .unified-input {
-        height: 40px;
-        background: #202225;
-        border: 1px solid #2f3136;
-        border-radius: 4px;
-        color: #dcddde;
-        width: 100%;
+      .uniform-control {
+        height: 42px;
         box-sizing: border-box;
-        padding: 0 12px;
-      }
-
-      .custom-select-container {
-        position: relative;
-        display: flex;
-        overflow: hidden;
-        align-items: center;
-        gap: 0.5rem;
-        cursor: pointer;
-      }
-
-      .custom-select-container.active {
-        border-color: #6f8cff;
-        box-shadow: 0 0 0 3px rgba(111, 140, 255, 0.18);
-      }
-
-      .custom-select-value {
+        border: 1px solid #40444b;
+        background-color: #2f3136;
+        color: #dcddde;
+        border-radius: 4px;
+        font-size: 14px;
+        padding: 0 10px;
         display: flex;
         align-items: center;
-        gap: 0.35rem;
-        flex-wrap: nowrap;
-        flex: 1;
-        min-height: 24px;
-        overflow: hidden;
+        width: 100%;
+      }
+
+      #filterResetBtn {
         white-space: nowrap;
+        cursor: pointer;
+        font-weight: 600;
+        width: auto;
+        text-transform: uppercase;
+      }
+
+      .tag-select-container {
+        position: relative;
+        flex: 1 1 200px;
+        min-width: 200px;
+      }
+
+      .tag-select-box {
+        cursor: pointer;
+        width: 100%;
+        min-height: 42px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .tag-dropdown {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        width: 100%;
+        z-index: 100;
+        display: none;
+        background: #2f3136;
+        border: 1px solid #202225;
+        max-height: 200px;
+        overflow-y: auto;
+      }
+
+      .tag-select-container.active .tag-dropdown {
+        display: block;
       }
 
       .custom-select-placeholder {
         color: #9ca3af;
-      }
-
-      .custom-select-arrow {
-        margin-left: auto;
-        opacity: 0.8;
-      }
-
-      .custom-select-dropdown {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: calc(100% + 6px);
-        background: #1b1e24;
-        border: 1px solid #31343a;
-        border-radius: 10px;
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
-        padding: 0.35rem;
-        display: none;
-        max-height: 260px;
-        overflow: auto;
-        z-index: 10;
-      }
-
-      .custom-select-container.active .custom-select-dropdown {
-        display: block;
       }
 
       .custom-select-option {
@@ -3124,58 +3113,48 @@
           </div>
 
           <div class="clip-filters">
-            <div class="filter-row">
-              <div class="filter-group">
-                <label for="videoSearchInput">Keresés cím vagy fájlnév alapján</label>
-                <input
-                  id="videoSearchInput"
-                  class="unified-input"
-                  type="search"
-                  placeholder="Pl. epikus csata"
-                />
+            <div class="filter-group" style="flex: 2;">
+              <label for="videoSearchInput">Keresés cím vagy fájlnév alapján</label>
+              <input
+                id="videoSearchInput"
+                class="uniform-control"
+                type="search"
+                placeholder="Pl. epikus csata"
+              />
+            </div>
+            <div class="filter-group" style="flex: 2;">
+              <label>Címke</label>
+              <div class="tag-select-container" id="tagSelectContainer">
+                <div class="tag-select-box uniform-control">Válassz címkéket...</div>
+                <div class="tag-dropdown"></div>
               </div>
-              <div class="filter-group">
-                <label for="tagMultiSelect">Címke</label>
-                <div
-                  class="custom-select-container unified-input"
-                  id="tagMultiSelect"
-                  role="combobox"
-                  aria-expanded="false"
-                  aria-controls="tagSelectDropdown"
-                  tabindex="0"
-                >
-                  <div class="custom-select-value" id="tagSelectValue" aria-live="polite"></div>
-                  <span class="custom-select-arrow" aria-hidden="true">▾</span>
-                  <div class="custom-select-dropdown" id="tagSelectDropdown" role="listbox" aria-multiselectable="true"></div>
-                </div>
-              </div>
-              <div class="filter-group">
-                <label for="sortOrderSelect">Rendezés</label>
-                <select id="sortOrderSelect" class="unified-input">
-                  <option value="newest">Legújabb elöl</option>
-                  <option value="oldest">Legrégebbi elöl</option>
-                </select>
-              </div>
-              <div class="filter-group">
-                <label for="videoQualitySelect">Minőség</label>
-                <select id="videoQualitySelect" class="unified-input">
-                  <option value="1080p">Eredeti (1080p)</option>
-                  <option value="720p">HD (720p)</option>
-                </select>
-              </div>
-              <div class="filter-group">
-                <label for="pageSizeSelect">Videók száma / oldal</label>
-                <select id="pageSizeSelect" class="unified-input">
-                  <option value="12">12</option>
-                  <option value="24" selected>24</option>
-                  <option value="40">40</option>
-                  <option value="80">80</option>
-                </select>
-              </div>
-              <div class="filter-group filter-group--actions">
-                <label class="sr-only" for="filterResetBtn">Szűrők törlése</label>
-                <button id="filterResetBtn" class="secondary-btn unified-input">Szűrők törlése</button>
-              </div>
+            </div>
+            <div class="filter-group">
+              <label for="sortOrderSelect">Rendezés</label>
+              <select id="sortOrderSelect" class="uniform-control">
+                <option value="newest">Legújabb elöl</option>
+                <option value="oldest">Legrégebbi elöl</option>
+              </select>
+            </div>
+            <div class="filter-group">
+              <label for="videoQualitySelect">Minőség</label>
+              <select id="videoQualitySelect" class="uniform-control">
+                <option value="1080p">Eredeti (1080p)</option>
+                <option value="720p">HD (720p)</option>
+              </select>
+            </div>
+            <div class="filter-group">
+              <label for="pageSizeSelect">Videók száma / oldal</label>
+              <select id="pageSizeSelect" class="uniform-control">
+                <option value="12">12</option>
+                <option value="24" selected>24</option>
+                <option value="40">40</option>
+                <option value="80">80</option>
+              </select>
+            </div>
+            <div class="filter-group filter-group--actions">
+              <label class="sr-only" for="filterResetBtn">Szűrők törlése</label>
+              <button id="filterResetBtn" class="secondary-btn uniform-control">Szűrők törlése</button>
             </div>
           </div>
 
@@ -6744,9 +6723,9 @@
       const MAX_UPLOAD_FILES = 100;
       const globalTagSelect = document.getElementById("globalTagSelect");
       const videoSearchInput = document.getElementById("videoSearchInput");
-      const tagMultiSelect = document.getElementById("tagMultiSelect");
-      const tagSelectValue = document.getElementById("tagSelectValue");
-      const tagSelectDropdown = document.getElementById("tagSelectDropdown");
+      const tagSelectContainer = document.getElementById("tagSelectContainer");
+      const tagSelectBox = tagSelectContainer?.querySelector(".tag-select-box");
+      const tagSelectDropdown = tagSelectContainer?.querySelector(".tag-dropdown");
       const sortOrderSelect = document.getElementById("sortOrderSelect");
       const videoQualitySelect = document.getElementById("videoQualitySelect");
       const pageSizeSelect = document.getElementById("pageSizeSelect");
@@ -7177,14 +7156,14 @@
       }
 
       function renderSelectedTagChips() {
-        if (!tagSelectValue) return;
-        tagSelectValue.innerHTML = "";
+        if (!tagSelectBox) return;
+        tagSelectBox.innerHTML = "";
 
         if (!videoFilters.tag.length) {
           const placeholder = document.createElement("span");
           placeholder.className = "custom-select-placeholder";
-          placeholder.textContent = "Válassz címkéket";
-          tagSelectValue.appendChild(placeholder);
+          placeholder.textContent = "Válassz címkéket...";
+          tagSelectBox.appendChild(placeholder);
           return;
         }
 
@@ -7208,7 +7187,7 @@
           removeBtn.textContent = "×";
 
           chip.append(colorBar, label, removeBtn);
-          tagSelectValue.appendChild(chip);
+          tagSelectBox.appendChild(chip);
         });
       }
 
@@ -8133,15 +8112,8 @@
         });
       }
 
-      function toggleTagDropdown(forceState) {
-        if (!tagMultiSelect) return;
-        const shouldOpen = typeof forceState === "boolean" ? forceState : !tagMultiSelect.classList.contains("active");
-        tagMultiSelect.classList.toggle("active", shouldOpen);
-        tagMultiSelect.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
-      }
-
       function renderCustomTagSelect() {
-        if (!tagMultiSelect || !tagSelectDropdown || !tagSelectValue || tagSelectHandlersAttached) {
+        if (!tagSelectContainer || !tagSelectDropdown || !tagSelectBox || tagSelectHandlersAttached) {
           return;
         }
 
@@ -8177,34 +8149,25 @@
         };
 
         const handleContainerClick = (event) => {
+          event.stopPropagation();
           if (event.target.closest(".custom-select-chip__remove")) {
             return;
           }
           if (event.target.closest(".custom-select-option")) {
             return;
           }
-          toggleTagDropdown();
-        };
-
-        const handleContainerKeydown = (event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            toggleTagDropdown();
-          } else if (event.key === "Escape") {
-            toggleTagDropdown(false);
-          }
+          tagSelectContainer.classList.toggle("active");
         };
 
         const handleOutsideClick = (event) => {
-          if (!tagMultiSelect.contains(event.target)) {
-            toggleTagDropdown(false);
+          if (!tagSelectContainer.contains(event.target)) {
+            tagSelectContainer.classList.remove("active");
           }
         };
 
-        tagMultiSelect.addEventListener("click", handleContainerClick);
-        tagMultiSelect.addEventListener("keydown", handleContainerKeydown);
+        tagSelectContainer.addEventListener("click", handleContainerClick);
         tagSelectDropdown.addEventListener("click", handleOptionClick);
-        tagSelectValue.addEventListener("click", handleChipRemoval);
+        tagSelectBox.addEventListener("click", handleChipRemoval);
         document.addEventListener("click", handleOutsideClick);
 
         tagSelectHandlersAttached = true;


### PR DESCRIPTION
## Summary
- restyled the clip filters bar with new uniform control styling and updated tag dropdown container visuals
- rebuilt the filters markup to use the new tag selector structure and consistent control classes
- rewrote tag selector click handling to toggle the dropdown on container clicks and close when clicking outside while keeping selection logic intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483d2cf7848327a5640449d27bf2bd)