### PR TITLE
Store original video quality for playback selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7636,8 +7636,19 @@
         const normalizedQuality = normalizeQualityPreference(requestedQuality);
         const originalSource = video?.filename ? `/uploads/${video.filename}` : "";
         const availability = getQualityAvailability(video);
+        const originalQuality = (video?.original_quality || "").toString();
 
         if (normalizedQuality === "original") {
+          return {
+            src: originalSource,
+            originalSource,
+            resolvedQuality: "original",
+            requestedQuality: normalizedQuality,
+            availability,
+          };
+        }
+
+        if (normalizedQuality !== "original" && originalQuality === normalizedQuality) {
           return {
             src: originalSource,
             originalSource,

--- a/src/database.js
+++ b/src/database.js
@@ -65,6 +65,7 @@ async function initializeDatabase() {
         has_720p INTEGER DEFAULT 0,
         has_1080p INTEGER DEFAULT 0,
         has_1440p INTEGER DEFAULT 0,
+        original_quality TEXT,
         processing_status TEXT DEFAULT 'done',
         FOREIGN KEY (uploader_id) REFERENCES users(id)
       )
@@ -93,6 +94,9 @@ async function initializeDatabase() {
     );
     await client.query(
       "ALTER TABLE videos ADD COLUMN IF NOT EXISTS processing_status TEXT DEFAULT 'done'"
+    );
+    await client.query(
+      'ALTER TABLE videos ADD COLUMN IF NOT EXISTS original_quality TEXT'
     );
 
     await client.query(`


### PR DESCRIPTION
## Summary
- add database support for storing each video's original quality and populate it during processing and repairs
- expose original_quality through video listings and use it to inform frontend source selection logic

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499e6819c48327855ab6b308624a7d)