### PR TITLE
Order Dávid/Balázs name tags first on clip cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7845,6 +7845,33 @@
         return trimmed.replace(/\.[^.]+$/i, "").trim();
       }
 
+      const CLIP_NAME_TAGS = ["Dávid", "Balázs"];
+      const clipNameTagPriority = new Map(
+        CLIP_NAME_TAGS.map((name, index) => [name.toLowerCase(), index])
+      );
+
+      function orderClipTags(tags) {
+        if (!Array.isArray(tags)) return [];
+        if (tags.length < 2) return tags;
+
+        return [...tags].sort((first, second) => {
+          const firstName = (first?.name || "").toLowerCase();
+          const secondName = (second?.name || "").toLowerCase();
+          const firstIsName = clipNameTagPriority.has(firstName) ? 0 : 1;
+          const secondIsName = clipNameTagPriority.has(secondName) ? 0 : 1;
+
+          if (firstIsName !== secondIsName) {
+            return firstIsName - secondIsName;
+          }
+
+          if (firstIsName === 0 && secondIsName === 0) {
+            return clipNameTagPriority.get(firstName) - clipNameTagPriority.get(secondName);
+          }
+
+          return 0;
+        });
+      }
+
       async function handleClipTitleEdit(video, titleElement) {
         if (!video || !Number.isFinite(video.id)) {
           return;
@@ -7993,7 +8020,7 @@
 
           const tagList = document.createElement("div");
           tagList.className = "tag-list";
-          (video.tags || []).forEach((tag) => {
+          orderClipTags(video.tags || []).forEach((tag) => {
             const chip = document.createElement("span");
             chip.className = "tag-chip";
             chip.style.setProperty("--tag-color", normalizeColor(tag.color));


### PR DESCRIPTION
### Motivation
- Ensure that when clips have the two specific name tags, the name (Dávid or Balázs) always appears first in the tag chips on the clips grid.
- Make tag ordering deterministic and improve the visual consistency of clip cards.
- Limit the behavior to the UI rendering so existing tag data and server logic remain unchanged.

### Description
- Added `CLIP_NAME_TAGS` and a `clipNameTagPriority` map to declare and prioritize the name tags `Dávid` and `Balázs`.
- Implemented `orderClipTags(tags)` which sorts tags so configured name tags come first and preserves their configured order.
- Updated the clip card rendering in `renderVideoGrid` to call `orderClipTags(video.tags || [])` before creating tag chips.
- All changes are contained in `public/index.html` and only affect client-side tag rendering.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69556b47992c8327a095b793d0e68b87)